### PR TITLE
LPD-25678 New tag format for releases caused bug in some automations

### DIFF
--- a/modules/util/client-extension-util-spring-boot/src/test/java/com/liferay/client/extension/util/spring/boot/LiferayOAuth2ClientConfigurationDefaultTest.java
+++ b/modules/util/client-extension-util-spring-boot/src/test/java/com/liferay/client/extension/util/spring/boot/LiferayOAuth2ClientConfigurationDefaultTest.java
@@ -58,6 +58,15 @@ public class LiferayOAuth2ClientConfigurationDefaultTest {
 	}
 
 	@Test
+	public void testGetAuthorizationFailure() {
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage(
+			"Could not find ClientRegistration with id 'none'");
+
+		_liferayOAuth2AccessTokenManager.getAuthorization("none");
+	}
+
+	@Test
 	public void testGetAuthorizationSuccess() {
 		OAuth2AccessTokenResponse oAuth2AccessTokenResponse =
 			OAuth2AccessTokenResponse.withToken(
@@ -86,15 +95,6 @@ public class LiferayOAuth2ClientConfigurationDefaultTest {
 			expected,
 			_liferayOAuth2AccessTokenManager.getAuthorization(
 				"foo-baker-headless-server"));
-	}
-
-	@Test
-	public void testGetAuthorizationFailure() {
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage(
-			"Could not find ClientRegistration with id 'none'");
-
-		_liferayOAuth2AccessTokenManager.getAuthorization("none");
 	}
 
 	@Rule

--- a/modules/util/client-extension-util-spring-boot/src/test/resources/com/liferay/client/extension/util/spring/boot/LiferayOAuth2ClientConfigurationExternalTest.properties
+++ b/modules/util/client-extension-util-spring-boot/src/test/resources/com/liferay/client/extension/util/spring/boot/LiferayOAuth2ClientConfigurationExternalTest.properties
@@ -10,4 +10,4 @@ external-headless-server.oauth2.token.uri=https://external-headless-server.com/o
 
 liferay.oauth.application.external.reference.codes=\
     default-headless-server,\
-    external-headless-server,\
+    external-headless-server

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/GradleUpgradeReleaseDXPCheck.java
@@ -42,7 +42,7 @@ public class GradleUpgradeReleaseDXPCheck extends BaseFileCheck {
 		throws Exception {
 
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_RELEASE_VERSION, absolutePath);
 
 		if (Validator.isNull(upgradeToVersion)) {
 			return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JSPUpgradeRemovedTagsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JSPUpgradeRemovedTagsCheck.java
@@ -37,7 +37,7 @@ public class JSPUpgradeRemovedTagsCheck extends BaseTagAttributesCheck {
 		String upgradeFromVersion = getAttributeValue(
 			SourceFormatterUtil.UPGRADE_FROM_VERSION, absolutePath);
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_RELEASE_VERSION, absolutePath);
 
 		if ((upgradeFromVersion == null) || (upgradeToVersion == null)) {
 			return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesUpgradeLiferayPluginPackageFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesUpgradeLiferayPluginPackageFileCheck.java
@@ -34,7 +34,7 @@ public class PropertiesUpgradeLiferayPluginPackageFileCheck
 		}
 
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION, absolutePath);
 
 		if (upgradeToVersion == null) {
 			return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesUpgradeLiferayPluginPackageLiferayVersionsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesUpgradeLiferayPluginPackageLiferayVersionsCheck.java
@@ -24,7 +24,7 @@ public class PropertiesUpgradeLiferayPluginPackageLiferayVersionsCheck
 	@Override
 	protected String getLiferayVersion(String absolutePath) {
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION, absolutePath);
 
 		String[] upgradeToVersionParts = StringUtil.split(
 			upgradeToVersion, StringPool.PERIOD);
@@ -46,7 +46,7 @@ public class PropertiesUpgradeLiferayPluginPackageLiferayVersionsCheck
 		}
 
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION, absolutePath);
 
 		if (upgradeToVersion == null) {
 			return true;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeCompatibilityVersionCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeCompatibilityVersionCheck.java
@@ -24,7 +24,7 @@ public class XMLUpgradeCompatibilityVersionCheck extends BaseFileCheck {
 		throws Exception {
 
 		_upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION, absolutePath);
 
 		if ((_upgradeToVersion == null) || !fileName.endsWith(".xml")) {
 			return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeDTDVersionCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeDTDVersionCheck.java
@@ -23,7 +23,7 @@ public class XMLUpgradeDTDVersionCheck extends XMLDTDVersionCheck {
 		throws IOException {
 
 		_upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION, absolutePath);
 
 		if ((_upgradeToVersion == null) || !fileName.endsWith(".xml")) {
 			return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeRemovedDefinitionsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLUpgradeRemovedDefinitionsCheck.java
@@ -77,7 +77,7 @@ public class XMLUpgradeRemovedDefinitionsCheck extends BaseFileCheck {
 		}
 
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION, absolutePath);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION, absolutePath);
 
 		String upgradeToVersionDTDFileName = _getUpgradeToVersionDTDFileName(
 			dtdFileName, upgradeFromVersion, upgradeToVersion);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
@@ -215,7 +215,8 @@ public class SourceChecksUtil {
 			attributesJSONObject, propertiesMap,
 			SourceFormatterUtil.GIT_LIFERAY_PORTAL_BRANCH,
 			SourceFormatterUtil.UPGRADE_FROM_VERSION,
-			SourceFormatterUtil.UPGRADE_TO_VERSION);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION,
+			SourceFormatterUtil.UPGRADE_TO_RELEASE_VERSION);
 
 		return SourceFormatterCheckUtil.addPropertiesAttributes(
 			attributesJSONObject, propertiesMap, CheckType.SOURCE_CHECK,

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UpgradeDeprecatedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UpgradeDeprecatedAPICheck.java
@@ -41,7 +41,7 @@ public class UpgradeDeprecatedAPICheck extends DeprecatedAPICheck {
 		String upgradeFromVersion = getAttributeValue(
 			SourceFormatterUtil.UPGRADE_FROM_VERSION);
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION);
+			SourceFormatterUtil.UPGRADE_TO_RELEASE_VERSION);
 
 		try {
 			JSONObject upgradeFromJavaClassesJSONObject =

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UpgradeRemovedAPICheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/UpgradeRemovedAPICheck.java
@@ -44,7 +44,7 @@ public class UpgradeRemovedAPICheck extends BaseAPICheck {
 		String upgradeFromVersion = getAttributeValue(
 			SourceFormatterUtil.UPGRADE_FROM_VERSION);
 		String upgradeToVersion = getAttributeValue(
-			SourceFormatterUtil.UPGRADE_TO_VERSION);
+			SourceFormatterUtil.UPGRADE_TO_RELEASE_VERSION);
 
 		try {
 			JSONObject upgradeFromJavaClassesJSONObject =

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/util/CheckstyleUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/util/CheckstyleUtil.java
@@ -231,7 +231,8 @@ public class CheckstyleUtil {
 			attributesJSONObject, propertiesMap,
 			SourceFormatterUtil.GIT_LIFERAY_PORTAL_BRANCH,
 			SourceFormatterUtil.UPGRADE_FROM_VERSION,
-			SourceFormatterUtil.UPGRADE_TO_VERSION);
+			SourceFormatterUtil.UPGRADE_TO_LIFERAY_VERSION,
+			SourceFormatterUtil.UPGRADE_TO_RELEASE_VERSION);
 
 		attributesJSONObject = SourceFormatterCheckUtil.addPropertiesAttributes(
 			attributesJSONObject, propertiesMap, CheckType.CHECKSTYLE,

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/util/SourceFormatterUtil.java
@@ -71,7 +71,11 @@ public class SourceFormatterUtil {
 	public static final String UPGRADE_INPUT_DATA_DIRECTORY_NAME =
 		"upgrade-to-7.4-input-data";
 
-	public static final String UPGRADE_TO_VERSION = "upgrade.to.version";
+	public static final String UPGRADE_TO_LIFERAY_VERSION =
+		"upgrade.to.liferay.version";
+
+	public static final String UPGRADE_TO_RELEASE_VERSION =
+		"upgrade.to.release.version";
 
 	public static List<String> filterFileNames(
 		List<String> allFileNames, String[] excludes, String[] includes,

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -264,7 +264,6 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 		sourceFormatterProperties.add(
 			"upgrade.to.liferay.version=" + _UPGRADE_TO_LIFERAY_VERSION);
-
 		sourceFormatterProperties.add(
 			"upgrade.to.release.version=" + _UPGRADE_TO_RELEASE_VERSION);
 

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeSourceProcessorTest.java
@@ -263,7 +263,10 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 		List<String> sourceFormatterProperties = new ArrayList<>();
 
 		sourceFormatterProperties.add(
-			"upgrade.to.version=" + _UPGRADE_TO_VERSION);
+			"upgrade.to.liferay.version=" + _UPGRADE_TO_LIFERAY_VERSION);
+
+		sourceFormatterProperties.add(
+			"upgrade.to.release.version=" + _UPGRADE_TO_RELEASE_VERSION);
 
 		SourceFormatterArgs sourceFormatterArgs =
 			super.getSourceFormatterArgs();
@@ -287,6 +290,8 @@ public class UpgradeSourceProcessorTest extends BaseSourceProcessorTestCase {
 		}
 	}
 
-	private static final String _UPGRADE_TO_VERSION = "7.4.13.u27";
+	private static final String _UPGRADE_TO_LIFERAY_VERSION = "7.4.13.u27";
+
+	private static final String _UPGRADE_TO_RELEASE_VERSION = "2024.q1.1";
 
 }


### PR DESCRIPTION
@michaelmdelcavalcanti

> **Context:** For the source formatter to apply some automations, it is necessary to create a file called source-formatter.properties in the customer's workspace Liferay and add a property that points to the new version that the workspace will receive, this property was called upgrade.to.version. The change in the format in which the release tag was defined caused some automations to stop working correctly. Previously a tag, such as `u92`, should be written in the form `7.4.13.u92`, but with the start of quarterly releases following a new format, such as `2024.q1.1`, this standard needed to be revised. Some automations require the tag to have the old format, while others require the tag to be in the new format. Therefore, it was understood that this tag would need to be divided, one to meet the old standard and one to meet the new standard, for the old standard a tag called upgrade.to.liferay.version was made, for the new standard a tag called upgrade.to.release.version was made, and then after creating the new tags the automations had their tags replaced according to their behavior.
> 
> **Note**: In general, the tag in the old format does not need to specify the exact release, the most important part being `7.4`, so leaving the tag written without specifying the release does not cause problems with automation, and it is suggested to use the tag as `7.4.13.u` or just `7.4`.
> 
> For more information, see the issue: [LPD-25678](https://liferay.atlassian.net/browse/LPD-25678)