### PR TITLE
master lpd 27841

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeCatchAllCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeCatchAllCheck.java
@@ -200,12 +200,13 @@ public class UpgradeCatchAllCheck extends BaseFileCheck {
 	private static Pattern _getPattern(JSONObject jsonObject) {
 		String from = jsonObject.getString("from");
 
+		if (jsonObject.getBoolean("fromRegex")) {
+			return Pattern.compile(from);
+		}
+
 		String regex = StringBundler.concat("\\b", from, "\\b");
 
-		if (from.contains("::")) {
-			return Pattern.compile(regex);
-		}
-		else if (regex.contains(StringPool.SLASH)) {
+		if (regex.contains(StringPool.SLASH)) {
 			return Pattern.compile(
 				StringUtil.replace(regex, CharPool.SLASH, "\\/"));
 		}

--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -22,6 +22,16 @@
 		"to": "getFriendlyURL(new InfoItemReference(param#0#, param#1#), param#2#)"
 	},
 	{
+		"classNames": [
+			"HttpServletRequest"
+		],
+		"from": "[a-z]\\w+\\.setAttribute\\(InfoDisplayWebKeys\\.INFO_ITEM_FIELD_VALUES_PROVIDER,.*?\\);",
+		"fromRegex": true,
+		"issueKey": "LPD-8022",
+		"skipParametersValidation": true,
+		"to": ""
+	},
+	{
 		"from": "CookieKeys.COMMERCE_CONTINUE_AS_GUEST",
 		"issueKey": "LPS-159679",
 		"newImports": [
@@ -496,6 +506,7 @@
 	},
 	{
 		"from": "AssetCategory::getLeftCategoryId",
+		"fromRegex": true,
 		"issueKey": "LPS-196624",
 		"to": "AssetCategory::getCategoryId"
 	},

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
@@ -119,6 +119,10 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		_commerceAccountHelper.getCurrentCommerceAccount(null);
 	}
 
+	public void method(HttpServletRequest httpServletRequest, Object value) {
+		httpServletRequest.setAttribute(null, null);
+	}
+
 	public void method(HttpServletRequest httpServletRequest, String name) {
 		CookieKeys.getCookie(httpServletRequest, "test123");
 		CookiesManagerUtil.getCookieValue(name, httpServletRequest);

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
@@ -105,6 +105,12 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		_commerceAccountHelper.getCurrentCommerceAccount(null);
 	}
 
+	public void method(HttpServletRequest httpServletRequest, Object value) {
+		httpServletRequest.setAttribute(null, null);
+		httpServletRequest.setAttribute(InfoDisplayWebKeys.INFO_ITEM_FIELD_VALUES_PROVIDER, value);
+		httpServletRequest.setAttribute(InfoDisplayWebKeys.INFO_ITEM_FIELD_VALUES_PROVIDER, infoItemServiceTracker.getFirstInfoItemService(InfoItemFieldValuesProvider.class, infoItemClassName));
+	}
+
 	public void method(HttpServletRequest httpServletRequest, String name) {
 		CookieKeys.getCookie(httpServletRequest, "test123");
 		CookieKeys.getCookie(httpServletRequest, name);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-27841

I made this change because the replacement requires a regex and cant use the more standard variable replaces or a hard replace. Mainly because
1) the first parameter requires to be a constant and
2) the second parameter can be anything and still be valid.

Its not possible to fulfill both conditions with the current infrastructure after some debugging, so I added support to allow regexes in the from attribute. I'm not sure if this is the best method though.

cc: @nicolas-sss @drewbrokke 