### PR TITLE
LRCI-4271 Release branches should always use deployed SF becasue SF in plugins might be too new that doesn't contain SF related changes, like source-formatter.properties

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -8527,15 +8527,11 @@ information. Make sure to commit in all build services results.
 				</exec>
 
 				<if>
-					<and>
-						<or>
-							<contains string="${git.diff}" substring="modules${file.separator}util${file.separator}source-formatter" />
-							<contains string="${git.diff}" substring="source-formatter.properties" />
-						</or>
-						<not>
-							<matches pattern="release-((\d{4})\.q([1-4])|(7\.[0-4]\.[0-9]?[0-9]\.\d+))" string="${liferay.portal.branch}" />
-						</not>
-					</and>
+					<or>
+						<contains string="${git.diff}" substring="modules${file.separator}util${file.separator}source-formatter" />
+						<contains string="${git.diff}" substring="source-formatter.properties" />
+						<matches pattern="release-((\d{4})\.q([1-4])|(7\.[0-4]\.[0-9]?[0-9]\.\d+))" string="${liferay.portal.branch}" />
+					</or>
 					<then>
 						<antcall target="compile" />
 
@@ -8547,7 +8543,20 @@ information. Make sure to commit in all build services results.
 								<gradle-execute dir="modules/util/source-formatter" task="deploy" />
 							</then>
 						</if>
+					</then>
+					<else>
+						<antcall target="setup-sdk" />
 
+						<antcall target="setup-yarn" />
+					</else>
+				</if>
+
+				<if>
+					<or>
+						<contains string="${git.diff}" substring="modules${file.separator}util${file.separator}source-formatter" />
+						<contains string="${git.diff}" substring="source-formatter.properties" />
+					</or>
+					<then>
 						<ant dir="portal-impl" target="format-source-all">
 							<property name="source.auto.fix" value="false" />
 							<property name="source.fail.on.auto.fix" value="true" />
@@ -8558,10 +8567,6 @@ information. Make sure to commit in all build services results.
 						</ant>
 					</then>
 					<else>
-						<antcall target="setup-sdk" />
-
-						<antcall target="setup-yarn" />
-
 						<ant dir="portal-impl" target="format-source-current-branch">
 							<property name="check.vulnerabilities" value="true" />
 							<property name="source.auto.fix" value="false" />


### PR DESCRIPTION
/cc @brittneyq

Q branches:
https://github.com/ling-alan-huang/liferay-portal-ee/pull/945
https://github.com/ling-alan-huang/liferay-portal-ee/pull/946
https://github.com/ling-alan-huang/liferay-portal-ee/pull/947
https://github.com/ling-alan-huang/liferay-portal-ee/pull/948 