### PR TITLE
LPD-33579 Update okhttp to version 4.10.0

### DIFF
--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/bnd.bnd
@@ -2,60 +2,21 @@ Bundle-Name: Liferay Document Library Opener OneDrive Web
 Bundle-SymbolicName: com.liferay.document.library.opener.onedrive.web
 Bundle-Version: 3.0.60
 Import-Package:\
-	!android.os,\
-	\
-	!android.util,\
-	\
-	!com.github.luben.*,\
-	\
-	!com.google.errorprone.annotations.*,\
-	\
-	!com.graphbuilder.*,\
-	\
-	!com.microsoft.schemas.office.powerpoint.*,\
-	!com.microsoft.schemas.office.word.*,\
+	!android.*,\
 	\
 	!com.sun.javadoc.*,\
 	!com.sun.tools.javadoc.*,\
 	\
-	!javax.annotation.meta.*,\
-	\
-	!junit.framework,\
-	\
 	!net.sf.saxon.*,\
 	\
-	!org.apache.batik.anim.dom.*,\
-	!org.apache.batik.bridge.*,\
-	!org.apache.batik.ext.awt.*,\
-	!org.apache.batik.gvt.*,\
-	!org.apache.batik.util.*,\
-	!org.apache.commons.math3.*,\
-	!org.apache.http.*,\
-	!org.apache.jcp.xml.dsig.internal.dom.*,\
-	!org.apache.poi.hsmf.*,\
-	!org.apache.poi.hwpf.extractor.*,\
 	!org.apache.tools.ant.*,\
 	\
 	!org.bouncycastle.*,\
 	\
-	!org.checkerframework.*,\
-	\
 	!org.conscrypt.*,\
 	\
-	!org.etsi.uri.x01903.v14.*,\
-	\
-	!org.joda.time.*,\
-	\
-	!org.json.simple.*,\
-	\
-	!org.junit.*,\
-	\
-	!org.openxmlformats.schemas.officeDocument.x2006.*,\
-	!org.openxmlformats.schemas.schemaLibrary.x2006.*,\
-	\
-	org.brotli.*;resolution:=optional,\
-	\
-	org.tukaani.*;resolution:=optional,\
+	!org.openjsse.javax.net.ssl.*,\
+	!org.openjsse.net.ssl.*,\
 	\
 	*
 Web-ContextPath: /document-library-opener-onedrive-web

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
@@ -10,20 +10,14 @@ dependencies {
 	compileInclude group: "org.jetbrains.kotlin", name: "kotlin-stdlib", version: "1.8.0"
 
 	compileOnly group: "com.google.code.gson", name: "gson", version: "2.9.0"
-	compileOnly group: "com.google.guava", name: "guava", version: "32.0.1-jre"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
-	compileOnly group: "com.zaxxer", name: "SparseBitSet", version: "1.2"
-	compileOnly group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
-	compileOnly group: "org.apache.commons", name: "commons-collections4", version: "4.4"
-	compileOnly group: "org.apache.commons", name: "commons-compress", version: "1.26.0"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.apache.poi", name: "poi", version: "5.2.2"
 	compileOnly group: "org.apache.poi", name: "poi-ooxml", version: "5.2.2"
-	compileOnly group: "org.apache.poi", name: "poi-ooxml-lite", version: "5.2.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:connected-app:connected-app-api")
 	compileOnly project(":apps:document-library-opener:document-library-opener-api")

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/build.gradle
@@ -4,7 +4,7 @@ dependencies {
 	compileInclude group: "com.googlecode.jsontoken", name: "jsontoken", version: "1.1"
 	compileInclude group: "com.microsoft.graph", name: "microsoft-graph", version: "1.5.0"
 	compileInclude group: "com.microsoft.graph", name: "microsoft-graph-core", version: "1.0.9"
-	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "3.12.1"
+	compileInclude group: "com.squareup.okhttp3", name: "okhttp", version: "4.10.0"
 	compileInclude group: "com.squareup.okio", name: "okio", version: "3.4.0"
 	compileInclude group: "org.apache.xmlbeans", name: "xmlbeans", version: "3.1.0"
 	compileInclude group: "org.jetbrains.kotlin", name: "kotlin-stdlib", version: "1.8.0"

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -594,6 +594,7 @@
         com.liferay.portletmvc4spring:com.liferay.portletmvc4spring.test:5.2.1,\
         com.rometools:rome:1.16.0,\
         com.rometools:rome-utils:1.16.0,\
+        com.squareup.okhttp3:okhttp:4.10.0,\
         com.sun.mail:jakarta.mail:1.6.6,\
         com.thoughtworks.xstream:xstream:1.4.20,\
         com.zaxxer:HikariCP:4.0.3,\


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-33579

There are two main apps using okhttp: the one drive integration for DM and the portal k8s agent.  This PR contains the changes for One Drive.  I've (manually) verified that One Drive works correctly, so you can focus on the kubernetes agent exclusively.