### PR TITLE
LPD-30952 Remove incorrectly upgraded import since only some of the constants got moved to CommerceOrderPaymentConstants not all of them

### DIFF
--- a/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
+++ b/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
@@ -55,7 +55,6 @@ com.liferay.commerce.account.service.CommerceAccountGroupRelLocalServiceUtil=com
 com.liferay.commerce.account.service.CommerceAccountGroupRelService=com.liferay.account.service.AccountGroupRelService
 com.liferay.commerce.account.service.CommerceAccountGroupRelServiceUtil=com.liferay.account.service.AccountGroupRelServiceUtil
 com.liferay.commerce.constants.CommerceDestinationNames=com.liferay.portal.kernel.messaging.DestinationNames
-com.liferay.commerce.constants.CommerceOrderConstants=com.liferay.commerce.constants.CommerceOrderPaymentConstants
 com.liferay.commerce.model.CommerceCountry=com.liferay.portal.kernel.model.Country
 com.liferay.commerce.model.CommerceRegion=com.liferay.portal.kernel.model.Region
 com.liferay.commerce.product.content.util.CPContentHelper=com.liferay.commerce.product.content.helper.CPContentHelper


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-30952
Only need to update the imports.txt file, since the upgrades already exist in the replacements.json, we just need to remove the un-needed import upgrade as it breaks compile for usages of CommerceOrderConstants