### PR TITLE
LPD-31242 Add missing tests

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBaseModelListenerCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBaseModelListenerCheck.java
@@ -21,6 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
+ * @author Kyle Miho
  * @author Michael Cavalcanti
  */
 public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
@@ -38,6 +39,8 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 			return content;
 		}
 
+		_modelType = _getModelType(content);
+
 		for (JavaTerm childJavaTerm : javaClass.getChildJavaTerms()) {
 			if (!childJavaTerm.isJavaMethod()) {
 				continue;
@@ -45,7 +48,7 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 
 			JavaMethod javaMethod = (JavaMethod)childJavaTerm;
 
-			String newJavaMethodContent = _formatMethodDefinition(javaMethod);
+			String newJavaMethodContent = _formatMethod(javaMethod);
 
 			content = StringUtil.replace(
 				content, javaMethod.getContent(), newJavaMethodContent);
@@ -54,18 +57,43 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 		return content;
 	}
 
-	private String _formatMethodDefinition(JavaMethod javaMethod) {
-		String javaMethodContent = javaMethod.getContent();
-
+	private String _formatMethod(JavaMethod javaMethod) {
 		String javaMethodName = javaMethod.getName();
 
-		if (!javaMethodName.equals("onAfterUpdate") &&
-			!javaMethodName.equals("onBeforeUpdate")) {
+		if (javaMethodName.equals("onAfterUpdate") ||
+			javaMethodName.equals("onBeforeUpdate")) {
 
+			return _formatMethodDefinitionWithParameterUpgrade(javaMethod);
+		}
+
+		return _formatMethodDefinitionWithoutParameterUpgrade(javaMethod);
+	}
+
+	private String _formatMethodDefinitionWithoutParameterUpgrade(
+		JavaMethod javaMethod) {
+
+		String javaMethodContent = javaMethod.getContent();
+
+		Matcher matcher = _superMethodPattern.matcher(javaMethodContent);
+
+		if (!matcher.find()) {
 			return javaMethodContent;
 		}
 
-		javaMethodContent = _formatSuper(javaMethodContent);
+		String methodCall = JavaSourceUtil.getMethodCall(
+			javaMethodContent, matcher.start());
+
+		methodCall = methodCall.trim();
+
+		return StringUtil.replace(
+			javaMethodContent, methodCall,
+			_formatSuperMethod(methodCall, false));
+	}
+
+	private String _formatMethodDefinitionWithParameterUpgrade(
+		JavaMethod javaMethod) {
+
+		String javaMethodContent = javaMethod.getContent();
 
 		JavaSignature javaSignature = javaMethod.getSignature();
 
@@ -74,6 +102,8 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 		if (parameters.size() != 1) {
 			return javaMethodContent;
 		}
+
+		javaMethodContent = _formatSuperMethod(javaMethodContent, true);
 
 		JavaParameter javaParameter = parameters.get(0);
 
@@ -94,8 +124,10 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 			newParameters);
 	}
 
-	private String _formatSuper(String javaMethodContent) {
-		Matcher matcher = _superPattern.matcher(javaMethodContent);
+	private String _formatSuperMethod(
+		String javaMethodContent, boolean parameterUpgrade) {
+
+		Matcher matcher = _superMethodPattern.matcher(javaMethodContent);
 
 		if (!matcher.find()) {
 			return javaMethodContent;
@@ -104,18 +136,21 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 		String methodCall = JavaSourceUtil.getMethodCall(
 			javaMethodContent, matcher.start());
 
-		List<String> parameterList = JavaSourceUtil.getParameterList(
-			methodCall);
-
-		if (parameterList.size() != 1) {
-			return javaMethodContent;
-		}
-
 		String parameter = JavaSourceUtil.getParameters(methodCall);
 
-		String newParameters = StringBundler.concat(
-			"original", StringUtil.upperCaseFirstLetter(parameter),
-			StringPool.COMMA_AND_SPACE, parameter);
+		String newParameters;
+
+		if (parameterUpgrade) {
+			newParameters = StringBundler.concat(
+				"original", StringUtil.upperCaseFirstLetter(parameter),
+				StringPool.COMMA_AND_SPACE, parameter);
+		}
+		else {
+			newParameters = StringBundler.concat(
+				StringPool.OPEN_PARENTHESIS, _modelType,
+				StringPool.CLOSE_PARENTHESIS, parameter, ".clone(), ",
+				parameter);
+		}
 
 		String newMethodCall = StringUtil.replace(
 			methodCall, parameter, newParameters);
@@ -123,7 +158,21 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 		return StringUtil.replace(javaMethodContent, methodCall, newMethodCall);
 	}
 
-	private static final Pattern _superPattern = Pattern.compile(
-		"super.\\s*\\w+\\(\\s*.+\\)");
+	private String _getModelType(String content) throws Exception {
+		Matcher matcher = _modelTypePattern.matcher(content);
+
+		if (!matcher.find()) {
+			throw new Exception("Cannot find model type");
+		}
+
+		return matcher.group(1);
+	}
+
+	private static final Pattern _modelTypePattern = Pattern.compile(
+		"extends\\s+\\w+\\<(\\w+)\\>");
+	private static final Pattern _superMethodPattern = Pattern.compile(
+		"super\\.\\s*(onAfterUpdate|onBeforeUpdate)\\(\\s*\\w+\\)");
+
+	private String _modelType;
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBaseModelListenerCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/UpgradeJavaBaseModelListenerCheck.java
@@ -32,10 +32,9 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseUpgradeCheck {
 
 		JavaClass javaClass = JavaClassParser.parseJavaClass(fileName, content);
 
-		List<String> implementedClassNames =
-			javaClass.getImplementedClassNames();
+		List<String> extendedClassNames = javaClass.getExtendedClassNames();
 
-		if (implementedClassNames.contains("BaseModelListener")) {
+		if (!extendedClassNames.contains("BaseModelListener")) {
 			return content;
 		}
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
@@ -14,9 +14,9 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseModelListener<t> {
 
 	@Override
 	public void onAfterCreate(t model) {
-		t originalModel = (t)model.clone();
+		super.onAfterUpdate((t)model.clone(), model);
 
-		super.onAfterUpdate(originalModel, model);
+		super.onAfterUpdate((t)model.clone(), model);
 	}
 
 	@Override
@@ -26,9 +26,7 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseModelListener<t> {
 
 	@Override
 	public void onAfterRemove(t model) {
-		t originalModel = (t)model.clone();
-
-		super.onBeforeUpdate(originalModel, model);
+		super.onBeforeUpdate((t)model.clone(), model);
 	}
 
 	@Override
@@ -38,6 +36,8 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseModelListener<t> {
 
 	@Override
 	public void onAfterUpdate(t originalModel, t model) {
+		super.onAfterUpdate(originalModel, model);
+
 		super.onAfterUpdate(originalModel, model);
 	}
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
@@ -8,8 +8,42 @@ package com.liferay.source.formatter.dependencies.upgrade;
 public class UpgradeJavaBaseModelListenerCheck extends BaseModelListener<t> {
 
 	@Override
+	public void onAfterCreate(t model) {
+		super.onAfterCreate(model);
+	}
+
+	@Override
+	public void onAfterCreate(t model) {
+		t originalModel = (t)model.clone();
+
+		super.onAfterUpdate(originalModel, model);
+	}
+
+	@Override
+	public void onAfterRemove(t model) {
+		super.onAfterRemove(model);
+	}
+
+	@Override
+	public void onAfterRemove(t model) {
+		t originalModel = (t)model.clone();
+
+		super.onBeforeUpdate(originalModel, model);
+	}
+
+	@Override
+	public void onAfterUpdate(t originalModel, t model) {
+		super.onAfterCreate(model);
+	}
+
+	@Override
 	public void onAfterUpdate(t originalModel, t model) {
 		super.onAfterUpdate(originalModel, model);
+	}
+
+	@Override
+	public void onBeforeUpdate(t originalModel, t model) {
+		super.onAfterRemove(model);
 	}
 
 	@Override

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
@@ -15,6 +15,8 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseModelListener<t> {
 	@Override
 	public void onAfterCreate(t model) {
 		super.onAfterUpdate(model);
+
+		super.onAfterUpdate(model);
 	}
 
 	@Override
@@ -34,6 +36,8 @@ public class UpgradeJavaBaseModelListenerCheck extends BaseModelListener<t> {
 
 	@Override
 	public void onAfterUpdate(t model) {
+		super.onAfterUpdate(model);
+
 		super.onAfterUpdate(model);
 	}
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeJavaBaseModelListenerCheck.testjava
@@ -8,8 +8,38 @@ package com.liferay.source.formatter.dependencies.upgrade;
 public class UpgradeJavaBaseModelListenerCheck extends BaseModelListener<t> {
 
 	@Override
+	public void onAfterCreate(t model) {
+		super.onAfterCreate(model);
+	}
+
+	@Override
+	public void onAfterCreate(t model) {
+		super.onAfterUpdate(model);
+	}
+
+	@Override
+	public void onAfterRemove(t model) {
+		super.onAfterRemove(model);
+	}
+
+	@Override
+	public void onAfterRemove(t model) {
+		super.onBeforeUpdate(model);
+	}
+
+	@Override
+	public void onAfterUpdate(t model) {
+		super.onAfterCreate(model);
+	}
+
+	@Override
 	public void onAfterUpdate(t model) {
 		super.onAfterUpdate(model);
+	}
+
+	@Override
+	public void onBeforeUpdate(t model) {
+		super.onAfterRemove(model);
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-31242

@nicolas-sss Can you clarify what the problem is in LPD-31242? I did some research, and only beforeUpdate and afterUpdate got upgraded to add the originalModel parameter, the example in the bug appears to be incorrect from my perspective? I added tests to make sure we dont accidently upgrade the other modelListener tasks, the ones mentioned in the ticket to also add the originalModel parameters, but it seems to correctly pass the testing.