### PR TITLE
master lpd 40131

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/jsPortlet/modules/my-project/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/jsPortlet/modules/my-project/build.gradle
@@ -1,3 +1,7 @@
 node {
 	useNpm = true
 }
+
+packageRunBuild {
+	mustRunAfter ":yarnInstall"
+}

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/jsPortlet/modules/react-provider/build.gradle
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/jsPortlet/modules/react-provider/build.gradle
@@ -1,3 +1,7 @@
 node {
 	useNpm = true
 }
+
+packageRunBuild {
+	mustRunAfter ":yarnInstall"
+}

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/LiferayWorkspaceYarnPlugin.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/LiferayWorkspaceYarnPlugin.java
@@ -9,8 +9,6 @@ import com.liferay.gradle.plugins.NodeDefaultsPlugin;
 import com.liferay.gradle.plugins.node.NodeExtension;
 import com.liferay.gradle.plugins.node.YarnPlugin;
 import com.liferay.gradle.plugins.node.task.NpmInstallTask;
-import com.liferay.gradle.plugins.node.task.PackageRunTask;
-import com.liferay.gradle.plugins.node.task.PackageRunTestTask;
 import com.liferay.gradle.plugins.node.task.YarnInstallTask;
 import com.liferay.gradle.plugins.workspace.internal.util.GradleUtil;
 import com.liferay.gradle.plugins.workspace.task.SetUpYarnTask;
@@ -73,15 +71,6 @@ public class LiferayWorkspaceYarnPlugin extends YarnPlugin {
 						nodeExtension.setUseNpm(false);
 
 						npmInstallTask.finalizedBy(yarnInstallTaskProvider);
-					});
-				taskContainer.withType(
-					PackageRunTask.class,
-					packageRunTask -> {
-						if (packageRunTask instanceof PackageRunTestTask) {
-							return;
-						}
-
-						packageRunTask.mustRunAfter(yarnInstallTaskProvider);
 					});
 			});
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-40131
https://liferay.atlassian.net/browse/LPP-56189

- **LPD-40131 Revert "LPD-21814 gradle-plugins-workspace: fixes jsPortlet test failure"**
- **FAKE-GRADLE-CACHE**

Temporarily leaving in FAKE-GRADLE-CACHE for convenience. Tested locally on 12.1.1 and this fixes the customer issue. Running tests on CI to find where the potential test failure fix is located