### PR TITLE
LPD-40131 Use dependsOn insetad of finalizedBy to fix frontend tasks build order

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/FrontendPlugin.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/FrontendPlugin.java
@@ -97,7 +97,7 @@ public class FrontendPlugin implements Plugin<Project> {
 					if (GradleUtil.hasTask(
 							project, NodePlugin.PACKAGE_RUN_BUILD_TASK_NAME)) {
 
-						buildTask.finalizedBy(
+						buildTask.dependsOn(
 							NodePlugin.PACKAGE_RUN_BUILD_TASK_NAME);
 					}
 				}


### PR DESCRIPTION
Forwarded from: https://github.com/liferay-devtools/liferay-portal/pull/281
cc: @drewbrokke @annasuszter 

https://liferay.atlassian.net/browse/LPD-40131
https://liferay.atlassian.net/browse/LPP-56189