### PR TITLE
LPD-37047 [SF] Consistency for string attributes in *.yaml

### DIFF
--- a/.github/workflows/ci-publish-workspace.yaml
+++ b/.github/workflows/ci-publish-workspace.yaml
@@ -10,7 +10,7 @@ jobs:
             - name: Set up JDK 8
               uses: actions/setup-java@v3
               with:
-                  distribution: "temurin"
+                  distribution: temurin
                   java-version: "8"
             - name: Build with Ant
               run: ant

--- a/modules/apps/analytics/analytics-settings-rest-impl/rest-config.yaml
+++ b/modules/apps/analytics/analytics-settings-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../analytics-settings-rest-api/src/main/java"
 apiPackagePath: "com.liferay.analytics.settings.rest"
 application:
     baseURI: "/analytics-settings-rest"
-    className: "AnalyticsSettingsRESTApplication"
+    className: AnalyticsSettingsRESTApplication
     name: "Liferay.Analytyics.Settings.REST"
-author: "Riccardo Ferrari"
+author: Riccardo Ferrari
 clientDir: "../analytics-settings-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/batch-planner/batch-planner-rest-impl/rest-config.yaml
+++ b/modules/apps/batch-planner/batch-planner-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../batch-planner-rest-api/src/main/java"
 apiPackagePath: "com.liferay.batch.planner.rest"
 application:
     baseURI: "/batch-planner"
-    className: "BatchPlannerRESTApplication"
+    className: BatchPlannerRESTApplication
     name: "Liferay.Batch.Planner.REST"
-author: "Matija Petanjek"
+author: Matija Petanjek
 clientDir: "../batch-planner-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/bulk/bulk-rest-impl/rest-config.yaml
+++ b/modules/apps/bulk/bulk-rest-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../bulk-rest-api/src/main/java"
 apiPackagePath: "com.liferay.bulk.rest"
 application:
     baseURI: "/bulk"
-    className: "BulkRESTApplication"
+    className: BulkRESTApplication
     name: "Liferay.Bulk.REST"
 author: "Alejandro Tardín"
 clientDir: "../bulk-rest-client/src/main/java"

--- a/modules/apps/captcha/captcha-rest-impl/rest-config.yaml
+++ b/modules/apps/captcha/captcha-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../captcha-rest-api/src/main/java"
 apiPackagePath: "com.liferay.captcha.rest"
 application:
     baseURI: "/captcha"
-    className: "CaptchaRESTApplication"
+    className: CaptchaRESTApplication
     name: "Liferay.Captcha.REST"
-author: "Loc Pham"
+author: Loc Pham
 clientDir: "../captcha-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-config.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../change-tracking-rest-api/src/main/java"
 apiPackagePath: "com.liferay.change.tracking.rest"
 application:
     baseURI: "/change-tracking-rest"
-    className: "ChangeTrackingRESTApplication"
+    className: ChangeTrackingRESTApplication
     name: "Liferay.Change.Tracking.REST"
-author: "David Truong"
+author: David Truong
 clientDir: "../change-tracking-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-account-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-admin-account-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.account"
 application:
     baseURI: "/headless-commerce-admin-account"
-    className: "HeadlessCommerceAdminAccountApplication"
+    className: HeadlessCommerceAdminAccountApplication
     name: "Liferay.Headless.Commerce.Admin.Account"
-author: "Alessio Antonio Rendina"
+author: Alessio Antonio Rendina
 clientDir: "../headless-commerce-admin-account-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: false

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../headless-commerce-admin-catalog-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.catalog"
 application:
     baseURI: "/headless-commerce-admin-catalog"
-    className: "HeadlessCommerceAdminCatalogApplication"
+    className: HeadlessCommerceAdminCatalogApplication
     name: "Liferay.Headless.Commerce.Admin.Catalog"
 author: "Zoltán Takács"
 clientDir: "../headless-commerce-admin-catalog-client/src/main/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -3436,7 +3436,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -3455,7 +3455,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -3472,7 +3472,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -3487,10 +3487,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Currency"
                     description:
-                        "Successful operation"
+                        Successful operation
                 400:
                     description:
-                        "Invalid input"
+                        Invalid input
                 401:
                     content:
                         application/json:
@@ -3500,7 +3500,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 404:
                     content:
                         application/json:
@@ -3510,7 +3510,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 500:
                     content:
                         application/json:
@@ -3520,7 +3520,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -3537,7 +3537,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -3561,10 +3561,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Currency"
                     description:
-                        "Successful operation"
+                        Successful operation
                 400:
                     description:
-                        "Invalid input"
+                        Invalid input
                 401:
                     content:
                         application/json:
@@ -3574,7 +3574,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 404:
                     content:
                         application/json:
@@ -3584,7 +3584,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 500:
                     content:
                         application/json:
@@ -3594,7 +3594,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-channel-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-admin-channel-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.channel"
 application:
     baseURI: "/headless-commerce-admin-channel"
-    className: "HeadlessCommerceAdminChannelApplication"
+    className: HeadlessCommerceAdminChannelApplication
     name: "Liferay.Headless.Commerce.Admin.Channel"
-author: "Andrea Sbarra"
+author: Andrea Sbarra
 clientDir: "../headless-commerce-admin-channel-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: false

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-admin-inventory-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.inventory"
 application:
     baseURI: "/headless-commerce-admin-inventory"
-    className: "HeadlessCommerceAdminInventoryApplication"
+    className: HeadlessCommerceAdminInventoryApplication
     name: "Liferay.Headless.Commerce.Admin.Inventory"
-author: "Alessio Antonio Rendina"
+author: Alessio Antonio Rendina
 clientDir: "../headless-commerce-admin-inventory-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: false

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-inventory-impl/rest-openapi.yaml
@@ -49,7 +49,7 @@ components:
             properties:
                 errorCode:
                     description:
-                        "Internal error code mapping"
+                        Internal error code mapping
                     example: 996
                     readOnly: true
                     type: integer
@@ -63,7 +63,7 @@ components:
                     type: string
                 status:
                     description:
-                        "HTTP Status code"
+                        HTTP Status code
                     example: 404
                     readOnly: true
                     type: integer
@@ -131,7 +131,7 @@ components:
                     example: true
                     type: boolean
                 city:
-                    example: "Diamond Bar"
+                    example: Diamond Bar
                     type: string
                 countryISOCode:
                     example: US
@@ -172,13 +172,13 @@ components:
                     example: CA
                     type: string
                 street1:
-                    example: "1400 Montefino Ave"
+                    example: 1400 Montefino Ave
                     type: string
                 street2:
-                    example: "1st floor"
+                    example: 1st floor
                     type: string
                 street3:
-                    example: "suite 200"
+                    example: suite 200
                     type: string
                 type:
                     type: string
@@ -397,22 +397,22 @@ components:
                 authorizationCode:
                     authorizationUrl: /oauth/authorize
                     scopes:
-                        CommerceOpenApiAdmin.admin: "Grants access to admin operations"
-                        CommerceOpenApiAdmin.read: "Grants read access"
-                        CommerceOpenApiAdmin.write: "Grants write access"
+                        CommerceOpenApiAdmin.admin: Grants access to admin operations
+                        CommerceOpenApiAdmin.read: Grants read access
+                        CommerceOpenApiAdmin.write: Grants write access
                     tokenUrl: /oauth/token
             type: oauth2
 info:
     contact:
         email: team-commerce@liferay.com
-        name: "Commerce Team"
+        name: Commerce Team
     description:
         "Liferay Commerce Admin Inventory API. A Java client JAR is available for use with the group ID 'com.liferay',
         artifact ID 'com.liferay.headless.commerce.admin.inventory.client', and version '4.0.38'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Liferay Commerce Admin Inventory API"
+    title: Liferay Commerce Admin Inventory API
     version: v1.0
 openapi: 3.0.0
 paths:
@@ -426,7 +426,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -441,7 +441,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 204:
                     content:
                         application/json: {}
@@ -463,7 +463,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -478,10 +478,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ReplenishmentItem"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -491,7 +491,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -501,7 +501,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -511,7 +511,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -529,7 +529,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -553,10 +553,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ReplenishmentItem"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -566,7 +566,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -576,7 +576,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -586,7 +586,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -604,7 +604,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -628,10 +628,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ReplenishmentItem"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -641,7 +641,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -651,7 +651,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -661,7 +661,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -680,7 +680,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -695,7 +695,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 204:
                     content:
                         application/json: {}
@@ -716,7 +716,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -731,10 +731,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ReplenishmentItem"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -744,7 +744,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -754,7 +754,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -764,7 +764,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -781,7 +781,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -805,10 +805,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/ReplenishmentItem"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -818,7 +818,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -828,7 +828,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -838,7 +838,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -881,10 +881,10 @@ paths:
                                     $ref: "#/components/schemas/ReplenishmentItem"
                                 type: array
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -894,7 +894,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -904,7 +904,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -914,7 +914,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1339,7 +1339,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -1347,7 +1347,7 @@ paths:
             responses:
                 "204":
                     description:
-                        "No content"
+                        No content
                 "401":
                     content:
                         application/json:
@@ -1357,7 +1357,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1375,7 +1375,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -1390,10 +1390,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/WarehouseItem"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -1403,7 +1403,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1413,7 +1413,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1423,7 +1423,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1441,7 +1441,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -1464,7 +1464,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -1474,7 +1474,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1484,7 +1484,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1494,7 +1494,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1512,7 +1512,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -1545,7 +1545,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -1555,7 +1555,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1565,7 +1565,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1575,7 +1575,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1636,7 +1636,7 @@ paths:
                                     $ref: "#/components/schemas/WarehouseItem"
                                 type: array
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
                         "Invalid input. Happens if the search parameters are not passed\nor if the end date is prior to
@@ -1650,7 +1650,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1660,7 +1660,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1670,7 +1670,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1688,7 +1688,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -1696,7 +1696,7 @@ paths:
             responses:
                 "204":
                     description:
-                        "No content"
+                        No content
                 "401":
                     content:
                         application/json:
@@ -1706,7 +1706,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1723,7 +1723,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -1738,10 +1738,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/WarehouseItem"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -1751,7 +1751,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1761,7 +1761,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1771,7 +1771,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1788,7 +1788,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -1811,7 +1811,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -1821,7 +1821,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1831,7 +1831,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1841,7 +1841,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1893,10 +1893,10 @@ paths:
                                     $ref: "#/components/schemas/Warehouse"
                                 type: array
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -1906,7 +1906,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1916,7 +1916,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1926,7 +1926,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -1965,7 +1965,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -1975,7 +1975,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -1985,7 +1985,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -1995,7 +1995,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -2013,7 +2013,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -2031,7 +2031,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -2048,7 +2048,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -2062,10 +2062,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Warehouse"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -2075,7 +2075,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -2085,7 +2085,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -2095,7 +2095,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -2112,7 +2112,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -2134,7 +2134,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -2144,7 +2144,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -2154,7 +2154,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -2164,7 +2164,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -2181,7 +2181,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -2213,7 +2213,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -2223,7 +2223,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -2233,7 +2233,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -2243,7 +2243,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -2905,7 +2905,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -2933,10 +2933,10 @@ paths:
                                     $ref: "#/components/schemas/WarehouseItem"
                                 type: array
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -2946,7 +2946,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -2956,7 +2956,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -2966,7 +2966,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -2983,7 +2983,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource external reference code"
+                          The resource external reference code
                       example: AB-34098-789-N
                       minLength: 1
                       type: string
@@ -3015,7 +3015,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -3025,7 +3025,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -3035,7 +3035,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -3045,7 +3045,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -3063,7 +3063,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -3082,7 +3082,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -3099,7 +3099,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -3114,10 +3114,10 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Warehouse"
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -3127,7 +3127,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -3137,7 +3137,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -3147,7 +3147,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -3164,7 +3164,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -3187,7 +3187,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -3197,7 +3197,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -3207,7 +3207,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -3217,7 +3217,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -3931,7 +3931,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -3960,10 +3960,10 @@ paths:
                                     $ref: "#/components/schemas/WarehouseItem"
                                 type: array
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -3973,7 +3973,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -3983,7 +3983,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -3993,7 +3993,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -4010,7 +4010,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -4043,7 +4043,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -4053,7 +4053,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -4063,7 +4063,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -4073,7 +4073,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -4091,7 +4091,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -4120,10 +4120,10 @@ paths:
                                     $ref: "#/components/schemas/ReplenishmentItem"
                                 type: array
                     description:
-                        "Successful operation"
+                        Successful operation
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -4133,7 +4133,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -4143,7 +4143,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -4153,7 +4153,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -4171,7 +4171,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The resource Id"
+                          The resource Id
                       example: 30130
                       format: int64
                       minimum: 0
@@ -4209,7 +4209,7 @@ paths:
                         Updated
                 "400":
                     description:
-                        "Invalid input"
+                        Invalid input
                 "401":
                     content:
                         application/json:
@@ -4219,7 +4219,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Authentication information is missing or invalid"
+                        Authentication information is missing or invalid
                 "404":
                     content:
                         application/json:
@@ -4229,7 +4229,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "The specified resource was not found"
+                        The specified resource was not found
                 "500":
                     content:
                         application/json:
@@ -4239,7 +4239,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Error"
                     description:
-                        "Unexpected error"
+                        Unexpected error
             security:
                 - BasicAuth: []
                 - BearerAuth: []
@@ -4250,7 +4250,7 @@ paths:
                 - ReplenishmentItem
 servers:
     - description:
-          "Liferay Commerce API server"
+          Liferay Commerce API server
       url: "https://commerce.{environment}.liferay.com/commerce-admin-inventory/{basePath}"
       variables:
           basePath:
@@ -4281,7 +4281,7 @@ servers:
                   - http
                   - https
     - description:
-          "Liferay Commerce Local Development with Ngrok"
+          Liferay Commerce Local Development with Ngrok
       url: "{protocol}://{host}.ngrok.io/o/commerce-admin-inventory/{basePath}"
       variables:
           basePath:
@@ -4294,5 +4294,5 @@ servers:
                   - http
                   - https
     - description:
-          "SwaggerHub API Auto Mocking"
+          SwaggerHub API Auto Mocking
       url: "https://virtserver.swaggerhub.com/liferay6/commerce-admin-inventory/v1.0"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-order-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-admin-order-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.order"
 application:
     baseURI: "/headless-commerce-admin-order"
-    className: "HeadlessCommerceAdminOrderApplication"
+    className: HeadlessCommerceAdminOrderApplication
     name: "Liferay.Headless.Commerce.Admin.Order"
-author: "Alessio Antonio Rendina"
+author: Alessio Antonio Rendina
 clientDir: "../headless-commerce-admin-order-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: false

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-payment-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-admin-payment-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.payment"
 application:
     baseURI: "/headless-commerce-admin-payment"
-    className: "HeadlessCommerceAdminPaymentApplication"
+    className: HeadlessCommerceAdminPaymentApplication
     name: "Liferay.Headless.Commerce.Admin.Payment"
-author: "Alessio Antonio Rendina"
+author: Alessio Antonio Rendina
 clientDir: "../headless-commerce-admin-payment-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../headless-commerce-admin-pricing-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.pricing"
 application:
     baseURI: "/headless-commerce-admin-pricing"
-    className: "HeadlessCommerceAdminPricingApplication"
+    className: HeadlessCommerceAdminPricingApplication
     name: "Liferay.Headless.Commerce.Admin.Pricing"
 author: "Zoltán Takács"
 clientDir: "../headless-commerce-admin-pricing-client/src/main/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-pricing-impl/rest-openapi-v2.0.yaml
@@ -132,7 +132,7 @@ components:
                 amountFormatted:
                     type: string
                 couponCode:
-                    example: "SAVE20"
+                    example: SAVE20
                     type: string
                 customFields:
                     additionalProperties: true
@@ -199,7 +199,7 @@ components:
                     minimum: 0
                     type: integer
                 limitationType:
-                    example: "unlimited"
+                    example: unlimited
                     type: string
                 maximumDiscountAmount:
                     example: 25
@@ -243,7 +243,7 @@ components:
                     example: true
                     type: boolean
                 target:
-                    example: "subtotal"
+                    example: subtotal
                     type: string
                 title:
                     example: "20% Off"
@@ -1132,7 +1132,7 @@ components:
                     format: bigdecimal
                     type: number
                 modifierType:
-                    example: "percentage"
+                    example: percentage
                     type: string
                 neverExpire:
                     example: true
@@ -1162,7 +1162,7 @@ components:
                     format: double
                     type: number
                 target:
-                    example: "product"
+                    example: product
                     type: string
                 title:
                     example: "20% Off"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-admin-shipment-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.shipment"
 application:
     baseURI: "/headless-commerce-admin-shipment"
-    className: "HeadlessCommerceAdminShipmentApplication"
+    className: HeadlessCommerceAdminShipmentApplication
     name: "Liferay.Headless.Commerce.Admin.Shipment"
-author: "Andrea Sbarra"
+author: Andrea Sbarra
 clientDir: "../headless-commerce-admin-shipment-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: false

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-shipment-impl/rest-openapi.yaml
@@ -130,7 +130,7 @@ components:
                     readOnly: true
                     type: object
                 carrier:
-                    example: "FedEx"
+                    example: FedEx
                     type: string
                 createDate:
                     format: date
@@ -183,7 +183,7 @@ components:
                     minimum: 0
                     type: integer
                 shippingOptionName:
-                    example: "Standard Delivery"
+                    example: Standard Delivery
                     readOnly: true
                     type: string
                 status:
@@ -193,10 +193,10 @@ components:
                     example: "123AD-asd"
                     type: string
                 trackingURL:
-                    example: "Standard Delivery"
+                    example: Standard Delivery
                     type: string
                 userName:
-                    example: "John"
+                    example: John
                     readOnly: true
                     type: string
             type: object
@@ -249,7 +249,7 @@ components:
                     example: s
                     type: string
                 userName:
-                    example: "John"
+                    example: John
                     readOnly: true
                     type: string
                 validateInventory:
@@ -326,10 +326,10 @@ components:
                     readOnly: true
                     type: integer
                 label:
-                    example: "black"
+                    example: black
                     type: string
                 label_i18n:
-                    example: "black"
+                    example: black
                     type: string
             type: object
     securitySchemes:
@@ -359,7 +359,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Liferay Commerce Admin Admin Shipment API"
+    title: Liferay Commerce Admin Admin Shipment API
     version: "v1.0"
 openapi: "3.0.0"
 paths:
@@ -550,7 +550,7 @@ paths:
                   required: true
                   schema:
                       description:
-                          "The shipment resource Id"
+                          The shipment resource Id
                       example: 30130
                       format: int64
                       minimum: 0

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-site-setting-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../headless-commerce-admin-site-setting-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.admin.site.setting"
 application:
     baseURI: "/headless-commerce-admin-site-setting"
-    className: "HeadlessCommerceAdminSiteSettingApplication"
+    className: HeadlessCommerceAdminSiteSettingApplication
     name: "Liferay.Headless.Commerce.Admin.Site.Setting"
 author: "Zoltán Takács"
 clientDir: "../headless-commerce-admin-site-setting-client/src/main/java"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-cart-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-delivery-cart-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.delivery.cart"
 application:
     baseURI: "/headless-commerce-delivery-cart"
-    className: "HeadlessCommerceDeliveryCartApplication"
+    className: HeadlessCommerceDeliveryCartApplication
     name: "Liferay.Headless.Commerce.Delivery.Cart"
-author: "Andrea Sbarra"
+author: Andrea Sbarra
 clientDir: "../headless-commerce-delivery-cart-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: false

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-catalog-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-delivery-catalog-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.delivery.catalog"
 application:
     baseURI: "/headless-commerce-delivery-catalog"
-    className: "HeadlessCommerceDeliveryCatalogApplication"
+    className: HeadlessCommerceDeliveryCatalogApplication
     name: "Liferay.Headless.Commerce.Delivery.Catalog"
-author: "Andrea Sbarra"
+author: Andrea Sbarra
 clientDir: "../headless-commerce-delivery-catalog-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-config.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-delivery-order-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.delivery.order"
 application:
     baseURI: "/headless-commerce-delivery-order"
-    className: "HeadlessCommerceDeliveryOrderApplication"
+    className: HeadlessCommerceDeliveryOrderApplication
     name: "Liferay.Headless.Commerce.Delivery.Order"
-author: "Andrea Sbarra"
+author: Andrea Sbarra
 clientDir: "../headless-commerce-delivery-order-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: false

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-delivery-order-impl/rest-openapi.yaml
@@ -445,11 +445,11 @@ components:
                     readOnly: true
                     type: integer
                 author:
-                    example: "Author"
+                    example: Author
                     readOnly: true
                     type: string
                 carrier:
-                    example: "FedEx"
+                    example: FedEx
                     readOnly: true
                     type: string
                 createDate:
@@ -502,7 +502,7 @@ components:
                     readOnly: true
                     type: integer
                 shippingOptionName:
-                    example: "Standard Delivery"
+                    example: Standard Delivery
                     readOnly: true
                     type: string
                 status:

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../data-engine-rest-api/src/main/java"
 apiPackagePath: "com.liferay.data.engine.rest"
 application:
     baseURI: "/data-engine"
-    className: "DataEngineRESTApplication"
+    className: DataEngineRESTApplication
     name: "Liferay.Data.Engine.REST"
-author: "Jeyvison Nascimento"
+author: Jeyvison Nascimento
 clientDir: "../data-engine-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
+++ b/modules/apps/data-engine/data-engine-rest-impl/rest-openapi.yaml
@@ -72,7 +72,7 @@ components:
                     format: int64
                     type: integer
                 indexType:
-                    default: "all"
+                    default: all
                     enum: [all, keyword, none, text]
                     type: string
                 indexable:
@@ -333,7 +333,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Data Engine"
+    title: Data Engine
     version: v2.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/digital-signature/digital-signature-rest-impl/rest-config.yaml
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../digital-signature-rest-api/src/main/java"
 apiPackagePath: "com.liferay.digital.signature.rest"
 application:
     baseURI: "/digital-signature-rest"
-    className: "DigitalSignatureRESTApplication"
+    className: DigitalSignatureRESTApplication
     name: "Liferay.Digital.Signature.REST"
 author: "José Abelenda"
 clientDir: "../digital-signature-rest-client/src/main/java"

--- a/modules/apps/dispatch/dispatch-rest-impl/rest-config.yaml
+++ b/modules/apps/dispatch/dispatch-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../dispatch-rest-api/src/main/java"
 apiPackagePath: "com.liferay.dispatch.rest"
 application:
     baseURI: "/dispatch-rest"
-    className: "DispatchRESTApplication"
+    className: DispatchRESTApplication
     name: "Liferay.Dispatch.REST"
-author: "Nilton Vieira"
+author: Nilton Vieira
 clientDir: "../dispatch-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-admin-address-api/src/main/java"
 apiPackagePath: "com.liferay.headless.admin.address"
 application:
     baseURI: "/headless-admin-address"
-    className: "HeadlessAdminAddressApplication"
+    className: HeadlessAdminAddressApplication
     name: "Liferay.Headless.Admin.Address"
-author: "Drew Brokke"
+author: Drew Brokke
 clientDir: "../headless-admin-address-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/rest-openapi.yaml
@@ -90,7 +90,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Admin Address"
+    title: Headless Admin Address
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-config.yaml
@@ -2,13 +2,13 @@ apiDir: "../headless-admin-content-api/src/main/java"
 apiPackagePath: "com.liferay.headless.admin.content"
 application:
     baseURI: "/headless-admin-content"
-    className: "HeadlessAdminContentApplication"
+    className: HeadlessAdminContentApplication
     name: "Liferay.Headless.Admin.Content"
-author: "Javier Gamarra"
+author: Javier Gamarra
 changeTrackingEnabled: true
 clientDir: "../headless-admin-content-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true
 generateBatch: false
-graphQLNamespace: "admin"
+graphQLNamespace: admin
 testDir: "../headless-admin-content-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/rest-openapi.yaml
@@ -188,7 +188,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Admin Content"
+    title: Headless Admin Content
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-admin-list-type-api/src/main/java"
 apiPackagePath: "com.liferay.headless.admin.list.type"
 application:
     baseURI: "/headless-admin-list-type"
-    className: "HeadlessAdminListTypeApplication"
+    className: HeadlessAdminListTypeApplication
     name: "Liferay.Headless.Admin.List.Type"
-author: "Gabriel Albuquerque"
+author: Gabriel Albuquerque
 clientDir: "../headless-admin-list-type-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-list-type/headless-admin-list-type-impl/rest-openapi.yaml
@@ -79,7 +79,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "List Type"
+    title: List Type
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-site/headless-admin-site-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../headless-admin-site-api/src/main/java"
 apiPackagePath: "com.liferay.headless.admin.site"
 application:
     baseURI: "/headless-admin-site"
-    className: "HeadlessAdminSiteApplication"
+    className: HeadlessAdminSiteApplication
     name: "Liferay.Headless.Admin.Site"
 author: "Rubén Pulido"
 clientDir: "../headless-admin-site-client/src/main/java"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-admin-taxonomy-api/src/main/java"
 apiPackagePath: "com.liferay.headless.admin.taxonomy"
 application:
     baseURI: "/headless-admin-taxonomy"
-    className: "HeadlessAdminTaxonomyApplication"
+    className: HeadlessAdminTaxonomyApplication
     name: "Liferay.Headless.Admin.Taxonomy"
-author: "Javier Gamarra"
+author: Javier Gamarra
 clientDir: "../headless-admin-taxonomy-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -375,7 +375,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Admin Taxonomy"
+    title: Headless Admin Taxonomy
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-admin-user-api/src/main/java"
 apiPackagePath: "com.liferay.headless.admin.user"
 application:
     baseURI: "/headless-admin-user"
-    className: "HeadlessAdminUserApplication"
+    className: HeadlessAdminUserApplication
     name: "Liferay.Headless.Admin.User"
-author: "Javier Gamarra"
+author: Javier Gamarra
 clientDir: "../headless-admin-user-client/src/main/java"
 compatibilityVersion: 6
 testDir: "../headless-admin-user-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1398,7 +1398,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Admin User"
+    title: Headless Admin User
     version: v1.0
 openapi: 3.0.1
 paths:
@@ -1466,7 +1466,7 @@ paths:
                                 $ref: "#/components/schemas/AccountGroup"
                     # @review
                     description:
-                        "AccountGroup successfully created"
+                        AccountGroup successfully created
             tags: ["AccountGroup"]
     "/account-groups/by-external-reference-code/{accountExternalReferenceCode}/accounts/by-external-reference-code/{externalReferenceCode}":
         delete:
@@ -1624,7 +1624,7 @@ paths:
                                 $ref: "#/components/schemas/AccountGroup"
                     # @review
                     description:
-                        "AccountGroup successfully updated"
+                        AccountGroup successfully updated
             tags: ["AccountGroup"]
         put:
             # @review
@@ -1657,7 +1657,7 @@ paths:
                                 $ref: "#/components/schemas/AccountGroup"
                     # @review
                     description:
-                        "AccountGroup successfully replaced"
+                        AccountGroup successfully replaced
             tags: ["AccountGroup"]
     "/account-groups/{accountGroupId}":
         delete:
@@ -1729,7 +1729,7 @@ paths:
                                 $ref: "#/components/schemas/AccountGroup"
                     # @review
                     description:
-                        "AccountGroup successfully updated"
+                        AccountGroup successfully updated
             tags: ["AccountGroup"]
         put:
             # @review
@@ -1763,7 +1763,7 @@ paths:
                                 $ref: "#/components/schemas/AccountGroup"
                     # @review
                     description:
-                        "AccountGroup successfully replaced"
+                        AccountGroup successfully replaced
             tags: ["AccountGroup"]
     "/account-groups/{accountGroupId}/accounts":
         get:
@@ -1875,7 +1875,7 @@ paths:
                                 $ref: "#/components/schemas/Account"
                     # @review
                     description:
-                        "Account successfully created"
+                        Account successfully created
             tags: ["Account"]
     "/accounts/by-external-reference-code/{accountExternalReferenceCode}/account-groups":
         get:
@@ -2187,7 +2187,7 @@ paths:
                                 $ref: "#/components/schemas/Account"
                     # @review
                     description:
-                        "Account successfully updated"
+                        Account successfully updated
             tags: ["Account"]
         put:
             # @review
@@ -2220,7 +2220,7 @@ paths:
                                 $ref: "#/components/schemas/Account"
                     # @review
                     description:
-                        "Account successfully replaced"
+                        Account successfully replaced
             tags: ["Account"]
     "/accounts/by-external-reference-code/{externalReferenceCode}/account-roles":
         get:
@@ -2921,7 +2921,7 @@ paths:
                                 $ref: "#/components/schemas/Account"
                     # @review
                     description:
-                        "Account successfully updated"
+                        Account successfully updated
             tags: ["Account"]
         put:
             # @review
@@ -2955,7 +2955,7 @@ paths:
                                 $ref: "#/components/schemas/Account"
                     # @review
                     description:
-                        "Account successfully replaced"
+                        Account successfully replaced
             tags: ["Account"]
     "/accounts/{accountId}/account-groups":
         get:
@@ -3701,7 +3701,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/EmailAddress"
                     description:
-                        "Email Address successfully updated"
+                        Email Address successfully updated
             tags: ["EmailAddress"]
     "/email-addresses/{emailAddressId}":
         delete:
@@ -3772,7 +3772,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/EmailAddress"
                     description:
-                        "Email Address successfully updated"
+                        Email Address successfully updated
             tags: ["EmailAddress"]
     "/my-user-account":
         get:
@@ -3946,7 +3946,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Organization"
                     description:
-                        "Organizations successfully created"
+                        Organizations successfully created
             tags: ["Organization"]
     "/organizations/by-external-reference-code/{externalReferenceCode}":
         delete:
@@ -4012,7 +4012,7 @@ paths:
                                 $ref: "#/components/schemas/Organization"
                     # @review
                     description:
-                        "Organization successfully updated"
+                        Organization successfully updated
             tags: ["Organization"]
         put:
             # @review
@@ -4044,7 +4044,7 @@ paths:
                                 $ref: "#/components/schemas/Organization"
                     # @review
                     description:
-                        "Organization successfully replaced"
+                        Organization successfully replaced
             tags: ["Organization"]
     "/organizations/by-external-reference-code/{externalReferenceCode}/accounts":
         delete:
@@ -4719,7 +4719,7 @@ paths:
                                 $ref: "#/components/schemas/Organization"
                     # @review
                     description:
-                        "Organization successfully updated"
+                        Organization successfully updated
             tags: ["Organization"]
         put:
             # @review
@@ -4751,7 +4751,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Organization"
                     description:
-                        "Organization successfully replaced"
+                        Organization successfully replaced
             tags: ["Organization"]
     "/organizations/{organizationId}/accounts":
         delete:
@@ -5689,7 +5689,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Role"
                     description:
-                        "Roles successfully created"
+                        Roles successfully created
             tags: ["Role"]
     "/roles/by-external-reference-code/{externalReferenceCode}":
         delete:
@@ -6568,7 +6568,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/UserAccount"
                     description:
-                        "UserAccount successfully updated"
+                        UserAccount successfully updated
             tags: ["UserAccount"]
         put:
             operationId: putUserAccountByExternalReferenceCode
@@ -6811,7 +6811,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/UserAccount"
                     description:
-                        "UserAccount successfully updated"
+                        UserAccount successfully updated
             tags: ["UserAccount"]
         put:
             # @review
@@ -6844,7 +6844,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/UserAccount"
                     description:
-                        "UserAccount successfully updated"
+                        UserAccount successfully updated
             tags: ["UserAccount"]
     "/user-accounts/{userAccountId}/email-addresses":
         get:

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-admin-workflow-api/src/main/java"
 apiPackagePath: "com.liferay.headless.admin.workflow"
 application:
     baseURI: "/headless-admin-workflow"
-    className: "HeadlessAdminWorkflowApplication"
+    className: HeadlessAdminWorkflowApplication
     name: "Liferay.Headless.Admin.Workflow"
-author: "Javier Gamarra"
+author: Javier Gamarra
 clientDir: "../headless-admin-workflow-client/src/main/java"
 compatibilityVersion: 6
 testDir: "../headless-admin-workflow-test/src/testIntegration/java"

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/rest-openapi.yaml
@@ -675,7 +675,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Admin Workflow"
+    title: Headless Admin Workflow
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-batch-engine-api/src/main/java"
 apiPackagePath: "com.liferay.headless.batch.engine"
 application:
     baseURI: "/headless-batch-engine"
-    className: "HeadlessBatchEngineApplication"
+    className: HeadlessBatchEngineApplication
     name: "Liferay.Headless.Batch.Engine"
-author: "Ivica Cardic"
+author: Ivica Cardic
 clientDir: "../headless-batch-engine-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/rest-openapi.yaml
@@ -159,7 +159,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Batch Engine"
+    title: Headless Batch Engine
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-delivery-api/src/main/java"
 apiPackagePath: "com.liferay.headless.delivery"
 application:
     baseURI: "/headless-delivery"
-    className: "HeadlessDeliveryApplication"
+    className: HeadlessDeliveryApplication
     name: "Liferay.Headless.Delivery"
-author: "Javier Gamarra"
+author: Javier Gamarra
 changeTrackingEnabled: true
 clientDir: "../headless-delivery-client/src/main/java"
 compatibilityVersion: 6

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -6164,7 +6164,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Delivery"
+    title: Headless Delivery
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-form-api/src/main/java"
 apiPackagePath: "com.liferay.headless.form"
 application:
     baseURI: "/headless-form"
-    className: "HeadlessFormApplication"
+    className: HeadlessFormApplication
     name: "Liferay.Headless.Form"
-author: "Javier Gamarra"
+author: Javier Gamarra
 clientDir: "../headless-form-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-form/headless-form-impl/rest-openapi.yaml
@@ -434,7 +434,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Headless Form"
+    title: Headless Form
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-portal-instances-api/src/main/java"
 apiPackagePath: "com.liferay.headless.portal.instances"
 application:
     baseURI: "/headless-portal-instances"
-    className: "HeadlessPortalInstancesApplication"
+    className: HeadlessPortalInstancesApplication
     name: "Liferay.Headless.Portal.Instances"
-author: "Alberto Chaparro"
+author: Alberto Chaparro
 clientDir: "../headless-portal-instances-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -192,7 +192,7 @@ paths:
                                 $ref: "#/components/schemas/PortalInstance"
                     # @review
                     description:
-                        "Portal instance successfully updated"
+                        Portal instance successfully updated
             # @review
             tags: ["PortalInstance"]
     /portal-instances/{portalInstanceId}/activate:

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../headless-site-api/src/main/java"
 apiPackagePath: "com.liferay.headless.site"
 application:
     baseURI: "/headless-site"
-    className: "HeadlessSiteApplication"
+    className: HeadlessSiteApplication
     name: "Liferay.Headless.Site"
 author: "Rubén Pulido"
 clientDir: "../headless-site-client/src/main/java"

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-user-notification-api/src/main/java"
 apiPackagePath: "com.liferay.headless.user.notification"
 application:
     baseURI: "/headless-user-notification"
-    className: "HeadlessUserNotificationApplication"
+    className: HeadlessUserNotificationApplication
     name: "Liferay.Headless.User.Notification"
-author: "Carlos Correa"
+author: Carlos Correa
 clientDir: "../headless-user-notification-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-user-notification/headless-user-notification-impl/rest-openapi.yaml
@@ -53,7 +53,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "HeadlessUserNotification"
+    title: HeadlessUserNotification
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/notification/notification-rest-impl/rest-config.yaml
+++ b/modules/apps/notification/notification-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../notification-rest-api/src/main/java"
 apiPackagePath: "com.liferay.notification.rest"
 application:
     baseURI: "/notification"
-    className: "NotificationRESTApplication"
+    className: NotificationRESTApplication
     name: "Liferay.Notification.REST"
-author: "Gabriel Albuquerque"
+author: Gabriel Albuquerque
 clientDir: "../notification-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/object/object-admin-rest-impl/rest-config.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../object-admin-rest-api/src/main/java"
 apiPackagePath: "com.liferay.object.admin.rest"
 application:
     baseURI: "/object-admin"
-    className: "ObjectAdminRESTApplication"
+    className: ObjectAdminRESTApplication
     name: "Liferay.Object.Admin.REST"
-author: "Javier Gamarra"
+author: Javier Gamarra
 clientDir: "../object-admin-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
+++ b/modules/apps/object/object-admin-rest-impl/rest-openapi.yaml
@@ -667,7 +667,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Object"
+    title: Object
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/object/object-rest-impl/rest-config.yaml
+++ b/modules/apps/object/object-rest-impl/rest-config.yaml
@@ -1,6 +1,6 @@
 apiDir: "../object-rest-api/src/main/java"
 apiPackagePath: "com.liferay.object.rest"
-author: "Javier Gamarra"
+author: Javier Gamarra
 compatibilityVersion: 6
 forcePredictableOperationId: true
 generateOpenAPI: false

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../portal-language-rest-api/src/main/java"
 apiPackagePath: "com.liferay.portal.language.rest"
 application:
     baseURI: "/language"
-    className: "PortalLanguageRESTApplication"
+    className: PortalLanguageRESTApplication
     name: "Liferay.Portal.Language.REST"
-author: "Thiago Buarque"
+author: Thiago Buarque
 clientDir: "../portal-language-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
+++ b/modules/apps/portal-language/portal-language-rest-impl/rest-openapi.yaml
@@ -16,7 +16,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Language"
+    title: Language
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
+++ b/modules/apps/portal-search/portal-search-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../portal-search-rest-api/src/main/java"
 apiPackagePath: "com.liferay.portal.search.rest"
 application:
     baseURI: "/search"
-    className: "PortalSearchRESTApplication"
+    className: PortalSearchRESTApplication
     name: "Liferay.Portal.Search.REST"
-author: "Petteri Karttunen"
+author: Petteri Karttunen
 clientDir: "../portal-search-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/dxp/apps/analytics/analytics-reports-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/analytics/analytics-reports-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../analytics-reports-rest-api/src/main/java"
 apiPackagePath: "com.liferay.analytics.reports.rest"
 application:
     baseURI: "/analytics-reports-rest"
-    className: "AnalyticsReportsRESTApplication"
+    className: AnalyticsReportsRESTApplication
     name: "Liferay.Analytics.Reports.REST"
-author: "Marcos Martins"
+author: Marcos Martins
 clientDir: "../analytics-reports-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-config.yaml
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-punchout-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.punchout"
 application:
     baseURI: "/headless-commerce-punchout"
-    className: "HeadlessCommercePunchOutApplication"
+    className: HeadlessCommercePunchOutApplication
     name: "Liferay.Headless.Commerce.PunchOut"
-author: "Jaclyn Ong"
+author: Jaclyn Ong
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: false
 generateGraphQL: false

--- a/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/commerce-punchout/headless/headless-commerce-punchout-impl/rest-openapi.yaml
@@ -370,7 +370,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Liferay Headless Commerce Punch Out"
+    title: Liferay Headless Commerce Punch Out
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-config.yaml
+++ b/modules/dxp/apps/commerce/headless/headless-commerce-machine-learning-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../headless-commerce-machine-learning-api/src/main/java"
 apiPackagePath: "com.liferay.headless.commerce.machine.learning"
 application:
     baseURI: "/headless-commerce-machine-learning"
-    className: "HeadlessCommerceMachineLEarningApplication"
+    className: HeadlessCommerceMachineLEarningApplication
     name: "Liferay.Headless.Commerce.Machine.Learning"
-author: "Riccardo Ferrari"
+author: Riccardo Ferrari
 clientDir: "../headless-commerce-machine-learning-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableSchemaPropertyName: true

--- a/modules/dxp/apps/osb/osb-faro/.travis.yml
+++ b/modules/dxp/apps/osb/osb-faro/.travis.yml
@@ -19,9 +19,9 @@ env:
 jdk: openjdk8
 jobs:
     include:
-        - name: "Analysis"
+        - name: Analysis
           script: ./gradlew checkSourceFormatting packageRunLint pmdMain pmdTest pmdTestIntegration spotbugsMain spotbugsTest spotbugsTestIntegration --configure-on-demand --continue --parallel
-        - name: "Tests"
+        - name: Tests
           after_success:
               - test ${TRAVIS_BRANCH} = "7.1.x" &&
                 test ${TRAVIS_EVENT_TYPE} = "push" &&

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../osb-testray-rest-api/src/main/java"
 apiPackagePath: "com.liferay.osb.testray.rest"
 application:
     baseURI: "/osb-testray-rest"
-    className: "OSBTestrayRESTApplication"
+    className: OSBTestrayRESTApplication
     name: "Liferay.OSB.Testray.REST"
 author: "José Abelenda"
 clientDir: "../osb-testray-rest-client/src/main/java"

--- a/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/osb/osb-testray/osb-testray-rest-impl/rest-openapi.yaml
@@ -18,7 +18,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "OSB Testray REST"
+    title: OSB Testray REST
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../portal-workflow-metrics-rest-api/src/main/java"
 apiPackagePath: "com.liferay.portal.workflow.metrics.rest"
 application:
     baseURI: "/portal-workflow-metrics"
-    className: "PortalWorkflowMetricsRESTApplication"
+    className: PortalWorkflowMetricsRESTApplication
     name: "Liferay.Portal.Workflow.Metrics.REST"
-author: "Rafael Praxedes"
+author: Rafael Praxedes
 clientDir: "../portal-workflow-metrics-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/dxp/apps/saml/saml-admin-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/saml/saml-admin-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../saml-admin-rest-api/src/main/java"
 apiPackagePath: "com.liferay.saml.admin.rest"
 application:
     baseURI: "/saml-admin"
-    className: "SamlAdminRESTApplication"
+    className: SamlAdminRESTApplication
     name: "Liferay.Saml.Admin.REST"
-author: "Stian Sigvartsen"
+author: Stian Sigvartsen
 clientDir: "../saml-admin-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../scim-rest-api/src/main/java"
 apiPackagePath: "com.liferay.scim.rest"
 application:
     baseURI: "/scim"
-    className: "ScimRESTApplication"
+    className: ScimRESTApplication
     name: "Liferay.Scim.REST"
 author: "Olivér Kecskeméty"
 clientDir: "../scim-rest-client/src/main/java"

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../search-experiences-rest-api/src/main/java"
 apiPackagePath: "com.liferay.search.experiences.rest"
 application:
     baseURI: "/search-experiences-rest"
-    className: "SearchExperiencesRESTApplication"
+    className: SearchExperiencesRESTApplication
     name: "Liferay.Search.Experiences.REST"
-author: "Brian Wing Shun Chan"
+author: Brian Wing Shun Chan
 clientDir: "../search-experiences-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/rest-config.yaml
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/rest-config.yaml
@@ -2,9 +2,9 @@ apiDir: "../segments-asah-rest-api/src/main/java"
 apiPackagePath: "com.liferay.segments.asah.rest"
 application:
     baseURI: "/segments-asah"
-    className: "SegmentsAsahRESTApplication"
+    className: SegmentsAsahRESTApplication
     name: "Liferay.Segments.Asah.REST"
-author: "Javier Gamarra"
+author: Javier Gamarra
 clientDir: "../segments-asah-rest-client/src/main/java"
 compatibilityVersion: 6
 forcePredictableOperationId: true

--- a/modules/dxp/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/segments/segments-asah-rest-impl/rest-openapi.yaml
@@ -73,7 +73,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Segments Asah"
+    title: Segments Asah
     version: v1.0
 openapi: 3.0.1
 paths:

--- a/modules/sdk/gradle-plugins-rest-builder/src/gradleTest/smoke/sample-rest/rest-config.yaml
+++ b/modules/sdk/gradle-plugins-rest-builder/src/gradleTest/smoke/sample-rest/rest-config.yaml
@@ -2,6 +2,6 @@ apiDir: "../sample-api/src/main/java"
 apiPackagePath: "com.example.sample"
 application:
     baseURI: "/sample"
-    className: "SampleApplication"
+    className: SampleApplication
     name: "sample-application"
-author: "John Doe"
+author: John Doe

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/with-company-scoped-global-js-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJS/with-company-scoped-global-js-client-extension/client-extension.yaml
@@ -1,5 +1,5 @@
 with-company-scoped-global-js-client-extension:
-    scope: "company"
-    scriptLocation: "head"
+    scope: company
+    scriptLocation: head
     type: globalJS
     url: src/dummy.js

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-invalid-scope-global-js-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-invalid-scope-global-js-client-extension/client-extension.yaml
@@ -1,4 +1,4 @@
 with-invalid-scope-global-js-client-extension:
-    scope: "foo"
+    scope: foo
     type: globalJS
     url: src/dummy.js

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-invalid-script-location-global-js-client-extension/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/clientExtensionTypeGlobalJSShouldFail/with-invalid-script-location-global-js-client-extension/client-extension.yaml
@@ -1,4 +1,4 @@
 with-invalid-script-location-global-js-client-extension:
-    scriptLocation: "foo"
+    scriptLocation: foo
     type: globalJS
     url: src/dummy.js

--- a/modules/sdk/gradle-plugins-workspace/src/gradleTest/designPack/design-packs/fire/client-extension.yaml
+++ b/modules/sdk/gradle-plugins-workspace/src/gradleTest/designPack/design-packs/fire/client-extension.yaml
@@ -1,5 +1,5 @@
 fire:
     clayURL: "css/clay.css"
     mainURL: "css/main.css"
-    name: "fire"
-    type: "themeCSS"
+    name: fire
+    type: themeCSS

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-config.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-config.yaml
@@ -2,7 +2,7 @@ apiDir: "../portal-tools-rest-builder-test-api/src/main/java"
 apiPackagePath: "com.liferay.portal.tools.rest.builder.test"
 application:
     baseURI: "/test"
-    className: "PortalToolsRESTBuilderTestApplication"
+    className: PortalToolsRESTBuilderTestApplication
     name: "Liferay.Portal.Tools.REST.Builder.Test"
 author: "Alejandro Tardín"
 changeTrackingEnabled: true

--- a/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
+++ b/modules/util/portal-tools-rest-builder-test-impl/rest-openapi.yaml
@@ -181,7 +181,7 @@ paths:
             responses:
                 "200":
                     description:
-                        "OK"
+                        OK
             tags: ["TestEntity"]
     /test-entities:
         get:
@@ -200,7 +200,7 @@ paths:
                                     $ref: "#/components/schemas/TestEntity"
                                 type: array
                     description:
-                        "OK"
+                        OK
             tags: ["TestEntity"]
         post:
             operationId: postTestEntity
@@ -236,7 +236,7 @@ paths:
                                 format: int32
                                 type: integer
                     description:
-                        "OK"
+                        OK
             tags: ["TestEntity"]
     /test-entities/{testEntityId}:
         get:
@@ -258,7 +258,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/TestEntity"
                     description:
-                        "OK"
+                        OK
             tags: ["TestEntity"]
         patch:
             operationId: patchTestEntity
@@ -293,7 +293,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/TestEntity"
                     description:
-                        "OK"
+                        OK
             tags: ["TestEntity"]
         put:
             operationId: putTestEntity
@@ -328,7 +328,7 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/TestEntity"
                     description:
-                        "OK"
+                        OK
             tags: ["TestEntity"]
     /test-entities/{testEntityId}/test-entity-address:
         get:
@@ -352,5 +352,5 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/TestEntityAddress"
                     description:
-                        "OK"
+                        OK
             tags: ["TestEntityAddress"]

--- a/modules/util/portal-tools-rest-builder/samples/rest-config.yaml
+++ b/modules/util/portal-tools-rest-builder/samples/rest-config.yaml
@@ -2,11 +2,11 @@ apiDir: "../sample-api/src/main/java"
 apiPackagePath: "com.example.sample"
 application:
     baseURI: "/sample"
-    className: "SampleApplication"
+    className: SampleApplication
     name: "sample-application"
     security:
         basicAuth: true
         guestAllowed: true
         oAuth2: true
-author: "John Doe"
+author: John Doe
 clientDir: "../sample-client/src/main/java"

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLStylingCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLStylingCheck.java
@@ -33,6 +33,12 @@ public class YMLStylingCheck extends BaseFileCheck {
 		content = content.replaceAll(
 			"(\\A|\n)( *)'([^'\"]+)'(:.*)(\\Z|\n)", "$1$2\"$3\"$4$5");
 
+		content = content.replaceAll(
+			"(\\A|\n)(( *)|(.+: ))" +
+				"(?!['\"](?i) *(?:yes|no|true|false|on|off) *['\"])" +
+					"['\"]((?=.*[a-zA-Z])[a-zA-Z\\d ]+)['\"](\\Z|\n)",
+			"$1$2$5$6");
+
 		if (fileName.endsWith("/rest-config.yaml")) {
 			content = content.replaceAll(
 				"(\\A|\n)( *baseURI: ((['\"](?!/))|(?!['\"/])))(.*)",

--- a/workspaces/liferay-testray-workspace/modules/testray-rest-impl/rest-config.yaml
+++ b/workspaces/liferay-testray-workspace/modules/testray-rest-impl/rest-config.yaml
@@ -2,8 +2,8 @@ apiDir: "../testray-rest-api/src/main/java"
 apiPackagePath: "com.liferay.testray.rest"
 application:
     baseURI: "/testray-rest"
-    className: "TestrayRESTApplication"
+    className: TestrayRESTApplication
     name: "Liferay.Testray.REST"
-author: "Nilton Vieira"
+author: Nilton Vieira
 compatibilityVersion: 4
 forcePredictableOperationId: true

--- a/workspaces/liferay-testray-workspace/modules/testray-rest-impl/rest-openapi.yaml
+++ b/workspaces/liferay-testray-workspace/modules/testray-rest-impl/rest-openapi.yaml
@@ -367,7 +367,7 @@ info:
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-    title: "Testray REST"
+    title: Testray REST
     version: v1.0
 openapi: 3.0.1
 paths:


### PR DESCRIPTION
This is an update for [LPD-37047](https://liferay.atlassian.net/browse/LPD-37047)

The regex matches string values inside single- or double-quotes where the string value only contains numbers, letters and spaces,  but it doesn't consist exclusively of numbers or valid boolean values (case-insensitive) and doesn't contain any special characters.

Source formatter removes the quotes from the matching strings.

@ling-alan-huang Can you please review my changes? Thank you! 

cc @drewbrokke 

 