### PR TITLE
LPD-37520 Import "company" scoped Global CSS CX

### DIFF
--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/BaseDynamicInclude.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/BaseDynamicInclude.java
@@ -133,8 +133,8 @@ public abstract class BaseDynamicInclude implements DynamicInclude {
 		}
 		catch (Exception exception) {
 			_log.error(
-				"Unable to inject global JavaScript client extensions for " +
-					"company " + themeDisplay.getCompanyId(),
+				"Unable to inject JavaScript client extensions for company " +
+					themeDisplay.getCompanyId(),
 				exception);
 		}
 	}

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/ClientExtensionTopHeadDynamicInclude.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/service/taglib/ClientExtensionTopHeadDynamicInclude.java
@@ -8,13 +8,20 @@ package com.liferay.client.extension.internal.service.taglib;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.internal.service.taglib.util.ClientExtensionDynamicIncludeUtil;
 import com.liferay.client.extension.model.ClientExtensionEntryRel;
+import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.GlobalCSSCET;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.content.security.policy.ContentSecurityPolicyNonceProviderUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -61,13 +68,40 @@ public class ClientExtensionTopHeadDynamicInclude implements DynamicInclude {
 				continue;
 			}
 
-			printWriter.print("<link data-senna-track=\"temporary\" href=\"");
-			printWriter.print(globalCSSCET.getURL());
-			printWriter.print(StringPool.QUOTE);
-			printWriter.print(
-				ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
-					httpServletRequest));
-			printWriter.print(" rel=\"stylesheet\" type=\"text/css\" />");
+			_writeStyleSheet(
+				httpServletRequest, printWriter, globalCSSCET.getURL());
+		}
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				themeDisplay.getCompanyId(), "LPD-34650")) {
+
+			return;
+		}
+
+		try {
+			List<CET> cets = _cetManager.getCETs(
+				themeDisplay.getCompanyId(), null,
+				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS,
+				Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS), null);
+
+			for (CET cet : cets) {
+				GlobalCSSCET globalCSSCET = (GlobalCSSCET)cet;
+
+				if (!StringUtil.equalsIgnoreCase(
+						globalCSSCET.getScope(), "company")) {
+
+					continue;
+				}
+
+				_writeStyleSheet(
+					httpServletRequest, printWriter, globalCSSCET.getURL());
+			}
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to inject CSS client extensions for company " +
+					themeDisplay.getCompanyId(),
+				exception);
 		}
 	}
 
@@ -76,6 +110,22 @@ public class ClientExtensionTopHeadDynamicInclude implements DynamicInclude {
 		dynamicIncludeRegistry.register(
 			"/html/common/themes/top_head.jsp#post");
 	}
+
+	private void _writeStyleSheet(
+		HttpServletRequest httpServletRequest, PrintWriter printWriter,
+		String url) {
+
+		printWriter.print("<link data-senna-track=\"temporary\" href=\"");
+		printWriter.print(url);
+		printWriter.print(StringPool.QUOTE);
+		printWriter.print(
+			ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
+				httpServletRequest));
+		printWriter.print(" rel=\"stylesheet\" type=\"text/css\" />");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ClientExtensionTopHeadDynamicInclude.class);
 
 	@Reference
 	private CETManager _cetManager;

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/internal/service/taglib/test/ClientExtensionTopHeadDynamicIncludeTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/internal/service/taglib/test/ClientExtensionTopHeadDynamicIncludeTest.java
@@ -15,6 +15,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -22,6 +23,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -64,6 +66,7 @@ public class ClientExtensionTopHeadDynamicIncludeTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_company = CompanyTestUtil.addCompany();
 		_group = GroupTestUtil.addGroup();
 	}
 
@@ -183,12 +186,15 @@ public class ClientExtensionTopHeadDynamicIncludeTest {
 			).build());
 	}
 
-	private MockHttpServletRequest _getMockHttpServletRequest(Layout layout) {
+	private MockHttpServletRequest _getMockHttpServletRequest(Layout layout)
+		throws Exception {
+
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
+		themeDisplay.setCompany(_company);
 		themeDisplay.setLayout(layout);
 
 		mockHttpServletRequest.setAttribute(
@@ -215,6 +221,9 @@ public class ClientExtensionTopHeadDynamicIncludeTest {
 	@Inject
 	private ClientExtensionEntryRelLocalService
 		_clientExtensionEntryRelLocalService;
+
+	@DeleteAfterTestRun
+	private Company _company;
 
 	@Inject(
 		filter = "component.name=com.liferay.client.extension.internal.service.taglib.ClientExtensionTopHeadDynamicInclude"

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/main/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptor.java
@@ -7,6 +7,7 @@ package com.liferay.client.extension.type.item.selector.web.internal.item.select
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.GlobalCSSCET;
 import com.liferay.client.extension.type.GlobalJSCET;
 import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.client.extension.type.item.selector.CETItemSelectorReturnType;
@@ -105,7 +106,17 @@ public class CETItemSelectorViewDescriptor
 
 	private Predicate<CET> _getPredicate(String type) {
 		if (Objects.equals(
-				type, ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
+				type, ClientExtensionEntryConstants.TYPE_GLOBAL_CSS)) {
+
+			return cet -> {
+				GlobalCSSCET globalCSSCET = (GlobalCSSCET)cet;
+
+				return !StringUtil.equalsIgnoreCase(
+					globalCSSCET.getScope(), "company");
+			};
+		}
+		else if (Objects.equals(
+					type, ClientExtensionEntryConstants.TYPE_GLOBAL_JS)) {
 
 			return cet -> {
 				GlobalJSCET globalJSCET = (GlobalJSCET)cet;

--- a/modules/apps/client-extension/client-extension-type-item-selector-web/src/test/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptorTest.java
+++ b/modules/apps/client-extension/client-extension-type-item-selector-web/src/test/java/com/liferay/client/extension/type/item/selector/web/internal/item/selector/CETItemSelectorViewDescriptorTest.java
@@ -7,11 +7,14 @@ package com.liferay.client.extension.type.item.selector.web.internal.item.select
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.type.CET;
+import com.liferay.client.extension.type.GlobalCSSCET;
 import com.liferay.client.extension.type.GlobalJSCET;
+import com.liferay.client.extension.type.ThemeCSSCET;
 import com.liferay.client.extension.type.item.selector.criterion.CETItemSelectorCriterion;
 import com.liferay.client.extension.type.manager.CETManager;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
 import com.liferay.portal.kernel.test.portlet.MockLiferayResourceRequest;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -65,11 +68,25 @@ public class CETItemSelectorViewDescriptorTest {
 
 	@Test
 	public void testGetSearchContainer() throws PortalException {
+		GlobalCSSCET globalCSSCET1 = Mockito.mock(GlobalCSSCET.class);
+
 		Mockito.when(
-			_cetItemSelectorCriterion.getType()
+			globalCSSCET1.getScope()
 		).thenReturn(
-			ClientExtensionEntryConstants.TYPE_GLOBAL_JS
+			"company"
 		);
+
+		GlobalCSSCET globalCSSCET2 = Mockito.mock(GlobalCSSCET.class);
+
+		Mockito.when(
+			globalCSSCET2.getScope()
+		).thenReturn(
+			""
+		);
+
+		_testGetSearchContainer(
+			globalCSSCET1, globalCSSCET2,
+			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
 
 		GlobalJSCET globalJSCET1 = Mockito.mock(GlobalJSCET.class);
 
@@ -87,13 +104,46 @@ public class CETItemSelectorViewDescriptorTest {
 			""
 		);
 
+		_testGetSearchContainer(
+			globalJSCET1, globalJSCET2,
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
+
+		ThemeCSSCET themeCSSCET1 = Mockito.mock(ThemeCSSCET.class);
+
+		Mockito.when(
+			themeCSSCET1.getScope()
+		).thenReturn(
+			"controlPanel"
+		);
+
+		ThemeCSSCET themeCSSCET2 = Mockito.mock(ThemeCSSCET.class);
+
+		Mockito.when(
+			themeCSSCET2.getScope()
+		).thenReturn(
+			""
+		);
+
+		_testGetSearchContainer(
+			themeCSSCET1, themeCSSCET2,
+			ClientExtensionEntryConstants.TYPE_THEME_CSS);
+	}
+
+	private void _testGetSearchContainer(CET cet1, CET cet2, String type)
+		throws PortalException {
+
+		Mockito.when(
+			_cetItemSelectorCriterion.getType()
+		).thenReturn(
+			type
+		);
+
 		Mockito.when(
 			_cetManager.getCETs(
-				Mockito.anyLong(), Mockito.any(),
-				Mockito.eq(ClientExtensionEntryConstants.TYPE_GLOBAL_JS),
+				Mockito.anyLong(), Mockito.any(), Mockito.eq(type),
 				Mockito.any(), Mockito.any())
 		).thenReturn(
-			Arrays.asList(globalJSCET1, globalJSCET2)
+			Arrays.asList(cet1, cet2)
 		);
 
 		SearchContainer<CET> searchContainer =
@@ -103,9 +153,10 @@ public class CETItemSelectorViewDescriptorTest {
 
 		Assert.assertEquals(results.toString(), 1, results.size());
 
-		GlobalJSCET globalJSCET3 = (GlobalJSCET)results.get(0);
+		CET cet3 = results.get(0);
 
-		Assert.assertEquals("", globalJSCET3.getScope());
+		Assert.assertEquals(
+			"", ReflectionTestUtil.invoke(cet3, "getScope", null));
 	}
 
 	private static CETItemSelectorCriterion _cetItemSelectorCriterion;


### PR DESCRIPTION
@drewbrokke this regards adding the `scope` attribute for the Global CSS CX, that PR was approved by devtool already ([see](https://github.com/liferay-devtools/liferay-portal/pull/314)). Sending here to speed things up, Evan is off until next week. 

----

https://liferay.atlassian.net/browse/LPD-37520

## Goal

To inject GlobalCSSCETs that are scoped to the company

## Approach

In `ClientExtensionTopHeadDynamicInclude.java`, import the GlobalCSSCETs CSS url that have `company` as value for the `scope` attribute. This import is not conditional, once the company scoped GlobalCSSCETs is deployed to portal, it's going to be imported (since the feature flag is enabled).

### Up next

I will be adding the sample and functional tests. See https://liferay.atlassian.net/browse/LPD-43551

cc: @ethib137