### PR TITLE
LPD-47697, LPD-47911 SF shouldn't touch CDATA section in xml, fix JavaModuleInternalImportsCheck

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
@@ -5,11 +5,13 @@
 
 package com.liferay.source.formatter.check;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.check.util.JavaSourceUtil;
 
 import java.io.File;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,8 +52,9 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 		String fileName, String absolutePath, String content) {
 
 		Matcher matcher = _internalImportPattern.matcher(content);
-
 		int pos = -1;
+		List<String> renamedSourceDirNames = getAttributeValues(
+			_RENAMED_SOURCE_DIR_NAMES_KEY, absolutePath);
 
 		while (matcher.find()) {
 			if (pos == -1) {
@@ -64,16 +67,17 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 				absolutePath.substring(0, pos + 13) +
 					StringUtil.replace(match, '.', '/') + ".java";
 
-			if (match.endsWith(
-					"wiki.engine.creole.internal.parser.parser." +
-						"Creole10Lexer") ||
-				match.endsWith(
-					"wiki.engine.creole.internal.parser.parser." +
-						"Creole10Parser")) {
+			for (String renamedSourceDirName : renamedSourceDirNames) {
+				String[] parts = StringUtil.split(
+					renamedSourceDirName, StringPool.COLON);
 
-				expectedImportFileLocation =
-					expectedImportFileLocation.replaceFirst(
-						"/src/main/java/", "/src/main/antlr/");
+				if (match.equals(parts[0])) {
+					expectedImportFileLocation =
+						expectedImportFileLocation.replaceFirst(
+							"/src/main/java/", "/src/main/" + parts[1] + "/");
+
+					break;
+				}
 			}
 
 			File file = new File(expectedImportFileLocation);
@@ -86,6 +90,9 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 			}
 		}
 	}
+
+	private static final String _RENAMED_SOURCE_DIR_NAMES_KEY =
+		"renamedSourceDirNames";
 
 	private static final Pattern _internalImportPattern = Pattern.compile(
 		"\nimport com\\.liferay\\.(.*\\.internal\\.([a-z].*?\\.)?[A-Z].*?)" +

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
@@ -71,9 +71,9 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 					renamedSourcePathName, StringPool.COLON);
 
 				if (match.equals(parts[0])) {
-					expectedImportFileLocation =
-						expectedImportFileLocation.replaceFirst(
-							"/src/main/java/", "/src/main/" + parts[1] + "/");
+					expectedImportFileLocation = StringUtil.replaceFirst(
+						expectedImportFileLocation, "/src/main/java/",
+						"/src/main/" + parts[1] + "/");
 
 					break;
 				}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
@@ -58,9 +58,23 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 				pos = absolutePath.lastIndexOf("/com/liferay/");
 			}
 
+			String match = matcher.group(1);
+
 			String expectedImportFileLocation =
 				absolutePath.substring(0, pos + 13) +
-					StringUtil.replace(matcher.group(1), '.', '/') + ".java";
+					StringUtil.replace(match, '.', '/') + ".java";
+
+			if (match.endsWith(
+					"wiki.engine.creole.internal.parser.parser." +
+						"Creole10Lexer") ||
+				match.endsWith(
+					"wiki.engine.creole.internal.parser.parser." +
+						"Creole10Parser")) {
+
+				expectedImportFileLocation =
+					expectedImportFileLocation.replaceFirst(
+						"/src/main/java/", "/src/main/antlr/");
+			}
 
 			File file = new File(expectedImportFileLocation);
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
@@ -52,6 +52,7 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 		String fileName, String absolutePath, String content) {
 
 		Matcher matcher = _internalImportPattern.matcher(content);
+
 		int pos = -1;
 		List<String> renamedSourcePathNames = getAttributeValues(
 			_RENAMED_SOURCE_PATH_NAMES_KEY, absolutePath);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
@@ -53,8 +53,8 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 
 		Matcher matcher = _internalImportPattern.matcher(content);
 		int pos = -1;
-		List<String> renamedSourceDirNames = getAttributeValues(
-			_RENAMED_SOURCE_DIR_NAMES_KEY, absolutePath);
+		List<String> renamedSourcePathNames = getAttributeValues(
+			_RENAMED_SOURCE_PATH_NAMES_KEY, absolutePath);
 
 		while (matcher.find()) {
 			if (pos == -1) {
@@ -67,9 +67,9 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 				absolutePath.substring(0, pos + 13) +
 					StringUtil.replace(match, '.', '/') + ".java";
 
-			for (String renamedSourceDirName : renamedSourceDirNames) {
+			for (String renamedSourcePathName : renamedSourcePathNames) {
 				String[] parts = StringUtil.split(
-					renamedSourceDirName, StringPool.COLON);
+					renamedSourcePathName, StringPool.COLON);
 
 				if (match.equals(parts[0])) {
 					expectedImportFileLocation =
@@ -91,8 +91,8 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 		}
 	}
 
-	private static final String _RENAMED_SOURCE_DIR_NAMES_KEY =
-		"renamedSourceDirNames";
+	private static final String _RENAMED_SOURCE_PATH_NAMES_KEY =
+		"renamedSourcePathNames";
 
 	private static final Pattern _internalImportPattern = Pattern.compile(
 		"\nimport com\\.liferay\\.(.*\\.internal\\.([a-z].*?\\.)?[A-Z].*?)" +

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaModuleInternalImportsCheck.java
@@ -53,20 +53,18 @@ public class JavaModuleInternalImportsCheck extends BaseFileCheck {
 
 		Matcher matcher = _internalImportPattern.matcher(content);
 
-		int pos = -1;
+		int pos = absolutePath.lastIndexOf("/com/liferay/");
+
+		String s = absolutePath.substring(0, pos + 13);
+
 		List<String> renamedSourcePathNames = getAttributeValues(
 			_RENAMED_SOURCE_PATH_NAMES_KEY, absolutePath);
 
 		while (matcher.find()) {
-			if (pos == -1) {
-				pos = absolutePath.lastIndexOf("/com/liferay/");
-			}
-
 			String match = matcher.group(1);
 
 			String expectedImportFileLocation =
-				absolutePath.substring(0, pos + 13) +
-					StringUtil.replace(match, '.', '/') + ".java";
+				s + StringUtil.replace(match, '.', '/') + ".java";
 
 			for (String renamedSourcePathName : renamedSourcePathNames) {
 				String[] parts = StringUtil.split(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLTagAttributesCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/XMLTagAttributesCheck.java
@@ -120,23 +120,21 @@ public class XMLTagAttributesCheck extends BaseTagAttributesCheck {
 				String trimmedLine = StringUtil.trimLeading(line);
 
 				if (sortAttributes) {
-					if (trimmedLine.startsWith(StringPool.LESS_THAN) &&
-						trimmedLine.endsWith(StringPool.GREATER_THAN) &&
-						!trimmedLine.startsWith("<?") &&
-						!trimmedLine.startsWith("<%") &&
-						!trimmedLine.startsWith("<!") &&
-						!(line.contains("<![CDATA[") && line.contains("]]>"))) {
+					if (line.contains("<![CDATA[")) {
+						sortAttributes = false;
+					}
+					else if (trimmedLine.startsWith(StringPool.LESS_THAN) &&
+							 trimmedLine.endsWith(StringPool.GREATER_THAN) &&
+							 !trimmedLine.startsWith("<?") &&
+							 !trimmedLine.startsWith("<%") &&
+							 !trimmedLine.startsWith("<!")) {
 
 						line = formatTagAttributes(
 							absolutePath, line, true, false);
 					}
-					else if (trimmedLine.startsWith("<![CDATA[") &&
-							 !trimmedLine.endsWith("]]>")) {
-
-						sortAttributes = false;
-					}
 				}
-				else if (trimmedLine.endsWith("]]>")) {
+
+				if (line.contains("]]>")) {
 					sortAttributes = true;
 				}
 

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1188,6 +1188,10 @@
 
     source.check.JavaModuleIllegalImportsCheck.enforcePetraStringBundler=true
 
+    source.check.JavaModuleInternalImportsCheck.renamedSourceDirNames=\
+        wiki.engine.creole.internal.parser.parser.Creole10Lexer:antlr,\
+        wiki.engine.creole.internal.parser.parser.Creole10Parser:antlr
+
     source.check.JavaModuleTestUtilCheck.enabled=true
 
     source.check.JavaModuleUniqueVerifyProcessCheck.enabled=true

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -1188,7 +1188,7 @@
 
     source.check.JavaModuleIllegalImportsCheck.enforcePetraStringBundler=true
 
-    source.check.JavaModuleInternalImportsCheck.renamedSourceDirNames=\
+    source.check.JavaModuleInternalImportsCheck.renamedSourcePathNames=\
         wiki.engine.creole.internal.parser.parser.Creole10Lexer:antlr,\
         wiki.engine.creole.internal.parser.parser.Creole10Parser:antlr
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-47697, see https://github.com/brianchandotcom/liferay-portal/pull/158258#issue-2819313776

https://liferay.atlassian.net/browse/LPD-47911, see https://github.com/liferay/liferay-portal/commit/dfaca1c, https://github.com/brianchandotcom/liferay-portal/pull/158339#issuecomment-2628763720
Fix:

```
java.lang.Exception: Found 2 formatting issues:
1: Do not import internal class from another module: ./modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/CreoleWikiEngine.java 20 (SourceCheck:JavaModuleInternalImportsCheck)
2: Do not import internal class from another module: ./modules/apps/wiki/wiki-engine-creole/src/main/java/com/liferay/wiki/engine/creole/internal/CreoleWikiEngine.java 21 (SourceCheck:JavaModuleInternalImportsCheck)
```