### PR TITLE
LPD-50042 SF, remove unnecessary whitespace before file extensions in test log

### DIFF
--- a/modules/dxp/apps/osb/osb-spring-boot/osb-spring-boot-client-zendesk/src/main/java/com/liferay/osb/spring/boot/client/zendesk/service/ZendeskService.java
+++ b/modules/dxp/apps/osb/osb-spring-boot/osb-spring-boot-client-zendesk/src/main/java/com/liferay/osb/spring/boot/client/zendesk/service/ZendeskService.java
@@ -95,12 +95,14 @@ public class ZendeskService {
 				new JSONObject(
 				).put(
 					"request",
-					new JSONObject().put(
+					new JSONObject(
+					).put(
 						"comment",
 						new JSONObject(
 						).put(
 							"html_body", htmlBody
-						))
+						)
+					)
 				).toString())
 		).retrieve(
 		).bodyToMono(

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeCatchAllCheckTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/UpgradeCatchAllCheckTest.java
@@ -42,7 +42,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class UpgradeCatchAllCheckTest extends BaseSourceProcessorTestCase {
 
-	@Parameterized.Parameters(name = "Testcase-{index}: Testing {0} .{1}")
+	@Parameterized.Parameters(name = "Testcase-{index}: Testing {0}.{1}")
 	public static Iterable<Object[]> data() throws Exception {
 		List<Object[]> objectsArray = new ArrayList<>();
 


### PR DESCRIPTION
Remove unnecessary whitespace before file extensions in test log:

```
com.liferay.source.formatter.processor.UpgradeCatchAllCheckTest > testUpgradeCatchAllCheck[Testcase-0: Testing LPS-198138 .java] STARTED

com.liferay.source.formatter.processor.UpgradeCatchAllCheckTest > testUpgradeCatchAllCheck[Testcase-0: Testing LPS-198138 .java] STANDARD_OUT
    WARNING: Setting property "java.parser.enabled" to "false" may prevent certain Java/JSP checks from working properly.

com.liferay.source.formatter.processor.UpgradeCatchAllCheckTest > testUpgradeCatchAllCheck[Testcase-0: Testing LPS-198138 .java] PASSED
```
