### PR TITLE
LPD-49291 Jakarta transform during ant all fails when Gradle caching is turned on

### DIFF
--- a/modules/apps/asset/asset-auto-tagger-opennlp-impl/build.gradle
+++ b/modules/apps/asset/asset-auto-tagger-opennlp-impl/build.gradle
@@ -1,9 +1,13 @@
+configurations {
+	bndOnly
+}
+
 dependencies {
-	compileOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.ner.location", version: "1.5.0"
-	compileOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.ner.organization", version: "1.5.0"
-	compileOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.ner.person", version: "1.5.0"
-	compileOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.sent", version: "1.5.0"
-	compileOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.token", version: "1.5.0"
+	bndOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.ner.location", version: "1.5.0"
+	bndOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.ner.organization", version: "1.5.0"
+	bndOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.ner.person", version: "1.5.0"
+	bndOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.sent", version: "1.5.0"
+	bndOnly classifier: "bin", ext: "bin", group: "com.liferay", name: "org.apache.opennlp.model.en.token", version: "1.5.0"
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.apache.opennlp", name: "opennlp-tools", version: "1.9.1"
@@ -15,4 +19,12 @@ dependencies {
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-concurrent")
 	compileOnly project(":core:petra:petra-reflect")
+}
+
+tasks.named("jar") {
+	Task jarTask ->
+
+	bundle {
+		classpath jarTask.project.configurations.bndOnly
+	}
 }

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -185,8 +185,6 @@ if (FileUtil.exists(rootProject, "private/yarn.lock")) {
 
 buildDir = new File(rootDir.parentFile, "build")
 
-File jakartaOutputDir = new File(buildDir, "_jakarta-transformer")
-
 for (String gradleVersion in ["8.5"]) {
 	String gradleDistributionURL = "https://services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 	String suffix = gradleVersion.replace(".", "")
@@ -1038,48 +1036,6 @@ private boolean _hasTestClasses(Task task, String testClassesDirName) {
 	}
 
 	return true
-}
-
-private synchronized FileCollection _transformToJakarta(File jakartaOutputDir, Configuration jakartaTransformerConfiguration, FileCollection jarFiles, Task task) {
-	FileCollection newJarFiles = task.project.objects.fileCollection()
-
-	File jakartaVersionsPropertiesFile = task.project.rootProject.file("liferay-jakarta-versions.properties")
-	URLClassLoader urlClassLoader = new URLClassLoader(jakartaTransformerConfiguration.files.collect { it.toURI() }.collect{ it.toURL() }.toArray(new URL[0]), null as java.lang.ClassLoader)
-
-	jarFiles.files.each {
-		File jarFile ->
-
-		String fileName = jarFile.name.contains('.') ? jarFile.name.replaceFirst(/(\.[^.]+)$/, '-JAKARTA-SNAPSHOT$1') : jarFile.name
-
-		File file = new File(jakartaOutputDir, fileName)
-
-		newJarFiles.from(file)
-
-		if (file.exists()) {
-			task.logger.lifecycle "Jakarta: CACHE ${task.project.name}:${task.name} ${FileUtil.relativize(jarFile, jakartaOutputDir.parentFile.parentFile.parentFile)} -> ${FileUtil.relativize(file, jakartaOutputDir.parentFile.parentFile.parentFile)}"
-
-			return
-		}
-
-		Class<?> jakartaTransformerCLIClass = Class.forName("org.eclipse.transformer.cli.JakartaTransformerCLI", true, urlClassLoader)
-
-		Object jakartaTransformerCLIClassConstructor = jakartaTransformerCLIClass.getConstructor(PrintStream, PrintStream, String[].class)
-		Object runMethod = jakartaTransformerCLIClass.getMethod("run")
-
-		PrintStream errorPrintStream = new PrintStream(new ByteArrayOutputStream())
-		PrintStream standardPrintStream = new PrintStream(new ByteArrayOutputStream())
-
-		Object resultCode = runMethod.invoke(jakartaTransformerCLIClassConstructor.newInstance(standardPrintStream, errorPrintStream, ["--quiet", "--versions", jakartaVersionsPropertiesFile.absolutePath, jarFile.absolutePath, file.absolutePath] as String[]))
-
-		if (resultCode.toString() == "Success") {
-			task.logger.lifecycle "Jakarta: ${task.project.name}:${task.name} ${FileUtil.relativize(jarFile, jakartaOutputDir.parentFile.parentFile.parentFile)} -> ${FileUtil.relativize(file, jakartaOutputDir.parentFile.parentFile.parentFile)}"
-		}
-		else {
-			throw new GradleException("Jakarta: ERROR ${resultCode}\n${errorPrintStream}")
-		}
-	}
-
-	return newJarFiles
 }
 
 private void _updateGradleSourcePaths(String gradleVersion, EclipseModel eclipseModel) {

--- a/modules/build.gradle
+++ b/modules/build.gradle
@@ -7,6 +7,9 @@ import com.liferay.gradle.util.copy.StripPathSegmentsAction
 
 import groovy.json.JsonSlurper
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
 import java.nio.file.Path
 
 import java.util.Objects
@@ -15,6 +18,10 @@ import java.util.concurrent.ConcurrentSkipListSet
 import org.apache.tools.ant.DirectoryScanner
 import org.apache.tools.ant.filters.ReplaceTokens
 
+import org.gradle.api.artifacts.transform.InputArtifact;
+import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformOutputs;
+import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.attributes.LibraryElements
 import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.plugins.ide.api.XmlFileContentMerger
@@ -44,6 +51,51 @@ ext {
 		"com.liferay.portal.tools.theme.builder.version": "1.1.9",
 		"com.liferay.portal.vulcan.api.version": "9.3.1"
 	]
+}
+
+abstract class JakartaTransformerTransformAction implements TransformAction<TransformParameters.None> {
+
+	public static final String ARTIFACT_TYPE = "jakarta-transformed-jar";
+
+	protected static Logger logger;
+	protected static ClassLoader classLoader;
+	protected static File propertiesFile;
+
+	@org.gradle.api.tasks.Classpath
+	@InputArtifact
+	abstract Provider<FileSystemLocation> getInputArtifact();
+
+	@Override
+	public void transform(TransformOutputs outputs) {
+		File inputJarFile = inputArtifact.get().asFile
+
+		String fileName = inputJarFile.name
+
+		if (fileName.contains('.')) {
+			fileName = fileName.replaceFirst(/(\.[^.]+)$/, '-JAKARTA-SNAPSHOT$1')
+		}
+
+		File outputJarFile = outputs.file(fileName)
+
+		Class<?> jakartaTransformerCLIClass = Class.forName("org.eclipse.transformer.cli.JakartaTransformerCLI", true, classLoader);
+
+		Constructor<?> jakartaTransformerCLIClassConstructor = jakartaTransformerCLIClass.getConstructor(PrintStream.class, PrintStream.class, String[].class);
+		Method runMethod = jakartaTransformerCLIClass.getMethod("run");
+
+		PrintStream errorPrintStream = new PrintStream(new ByteArrayOutputStream());
+		PrintStream standardPrintStream = new PrintStream(new ByteArrayOutputStream());
+
+		Object resultCode = runMethod.invoke(
+			jakartaTransformerCLIClassConstructor.newInstance(
+				standardPrintStream, errorPrintStream, ["--quiet", "--versions", propertiesFile.absolutePath, inputJarFile.absolutePath, outputJarFile.absolutePath ] as String[]));
+
+		if (!Objects.equals(resultCode.toString(), "Success")) {
+			throw new GradleException("Jakarta: ERROR ${resultCode}\n${errorPrintStream}")
+		}
+
+		logger.info("Jakarta:  {} -> {}", inputJarFile, outputJarFile);
+	}
+
 }
 
 task portalYarnCheckFormat
@@ -91,6 +143,14 @@ if (Boolean.getBoolean("build.jakarta.transformer.enabled")) {
 			url System.properties["repository.url"] ?: "https://repository-cdn.liferay.com/nexus/content/groups/public"
 		}
 	}
+
+	URLClassLoader urlClassLoader = new URLClassLoader(
+		configurations.jakartaTransformer.collect { it.toURI() }.collect{ it.toURL() }.toArray(new URL[0]),
+		null as java.lang.ClassLoader);
+
+	JakartaTransformerTransformAction.classLoader = urlClassLoader
+	JakartaTransformerTransformAction.logger = project.logger
+	JakartaTransformerTransformAction.propertiesFile = project.file("liferay-jakarta-versions.properties")
 }
 
 if (FileUtil.exists(rootProject, "private/yarn.lock")) {
@@ -814,106 +874,50 @@ gradle.beforeProject {
 			pluginManager.withPlugin("com.liferay.jasper.jspc") {
 				configurations {
 					compileJspClasspath
-					compileJspClasspathTransform
-
-					jspC {
+					compileJspClasspathTransform {
 						attributes {
-							attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
-						}
-
-						resolutionStrategy {
-							dependencySubstitution {
-								dependencySubstitutions ->
-
-								all {
-									DependencySubstitution dependencySubstitution ->
-									ComponentSelector requested = dependencySubstitution.requested
-
-									if (requested instanceof ModuleComponentSelector) {
-										if (requested.group == "javax.servlet.jsp.jstl" && requested.module == "javax.servlet.jsp.jstl-api") {
-											dependencySubstitution.useTarget group: "jakarta.servlet.jsp.jstl", name: "jakarta.servlet.jsp.jstl-api", version: "3.0.2"
-										}
-										if (requested.group == "org.apache.tomcat" && requested.module == "tomcat-jasper") {
-											dependencySubstitution.useTarget group: "org.apache.tomcat", name: "tomcat-jasper", version: "10.1.34"
-										}
-										if (requested.group == "org.glassfish.web" && requested.module == "javax.servlet.jsp.jstl") {
-											dependencySubstitution.useTarget group: "org.glassfish.web", name: "jakarta.servlet.jsp.jstl", version: "3.0.1"
-										}
-									}
-								}
-							}
+							attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, JakartaTransformerTransformAction.ARTIFACT_TYPE)
 						}
 					}
+					jspCClasspath
 				}
 
 				dependencies {
 					compileJspClasspath files(Project.class.classLoader.getURLs())
-					compileJspClasspath files(project.provider { _transformToJakarta(jakartaOutputDir, rootProject.configurations.jakartaTransformer, configurations.compileJspClasspathTransform, generateJSPJava) })
 					compileJspClasspath group: "org.apache.tomcat", name: "tomcat-jasper", version: "10.1.34"
 					compileJspClasspathTransform group: "com.liferay", name: "com.liferay.gradle.plugins.jasper.jspc", transitive: false, version: "2.0.20"
+					jspCClasspath files(tasks.named(sourceSets.main.compileJavaTaskName))
+					jspCClasspath files(tasks.named(sourceSets.main.processResourcesTaskName))
+					jspCClasspath group: "jakarta.servlet.jsp.jstl", name: "jakarta.servlet.jsp.jstl-api", version: "3.0.2"
+					jspCClasspath group: "org.apache.tomcat", name: "tomcat-jasper", version: "10.1.34"
+					jspCClasspath group: "org.glassfish.web", name: "jakarta.servlet.jsp.jstl", version: "3.0.1"
 				}
 
-				tasks.named("compileJSP") {
-					doFirst {
-						FileCollection jarFiles = files(classpath.files.findAll { it.name.endsWith(".jar") })
+				FileCollection jspCClasspathFileCollection = configurations[sourceSets.main.compileClasspathConfigurationName] + configurations.jspCClasspath
 
-						classpath = files(classpath - jarFiles) + _transformToJakarta(jakartaOutputDir, rootProject.configurations.jakartaTransformer, jarFiles, it)
-					}
+				tasks.named("compileJSP") {
+					classpath = jspCClasspathFileCollection
 				}
 
 				tasks.named("generateJSPJava") {
-					Task generateJSPJava ->
-
-					compileJspClasspath = configurations.compileJspClasspath
-
-					doFirst {
-						FileCollection jarFiles = files(jspCClasspath.files.findAll { it.name.endsWith(".jar") })
-
-						jspCClasspath = files(jspCClasspath - jarFiles) + _transformToJakarta(jakartaOutputDir, rootProject.configurations.jakartaTransformer, jarFiles, it)
-					}
+					compileJspClasspath = configurations.compileJspClasspath + configurations.compileJspClasspathTransform
+					jspCClasspath = jspCClasspathFileCollection
 				}
 			}
 
 			pluginManager.withPlugin("java") {
-				configurations.compileClasspath.attributes {
-					attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
-				}
-
-				configurations.testCompileClasspath.attributes {
-					attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
-				}
-
-				configurations.testIntegrationCompileClasspath.attributes {
-					attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
-				}
-
-				tasks.named("compileJava") {
-					doFirst {
-						FileCollection jarFiles = files(classpath.files.findAll { it.name.endsWith(".jar") })
-
-						classpath = files(classpath.files - jarFiles) + _transformToJakarta(jakartaOutputDir, rootProject.configurations.jakartaTransformer, jarFiles, it)
+				dependencies {
+					registerTransform(JakartaTransformerTransformAction) {
+						from.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE)
+						to.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, JakartaTransformerTransformAction.ARTIFACT_TYPE)
 					}
 				}
 
-				tasks.named("compileTestIntegrationJava") {
-					doFirst {
-						FileCollection jarFiles = files(classpath.files.findAll { it.name.endsWith(".jar") })
+				sourceSets.configureEach {
+					SourceSet sourceSet ->
 
-						classpath = files(classpath - jarFiles) + _transformToJakarta(jakartaOutputDir, rootProject.configurations.jakartaTransformer, jarFiles, it)
-					}
-				}
-
-				tasks.named("compileTestJava") {
-					doFirst {
-						FileCollection jarFiles = files(classpath.files.findAll { it.name.endsWith(".jar") })
-
-						classpath = files(classpath - jarFiles) + _transformToJakarta(jakartaOutputDir, rootProject.configurations.jakartaTransformer, jarFiles, it)
-					}
-				}
-
-				tasks.named("jar") {
-					classpath = tasks.named("compileJava").map {
-						it.classpath
+					configurations[sourceSet.compileClasspathConfigurationName].attributes {
+						attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, JakartaTransformerTransformAction.ARTIFACT_TYPE)
 					}
 				}
 			}

--- a/modules/settings.gradle
+++ b/modules/settings.gradle
@@ -47,9 +47,3 @@ if (testClassGroupIndex) {
 	gradle.ext.testClassGroupIndex = testClassGroupIndex
 	gradle.ext.testClassGroups = properties["TEST_CLASS_GROUPS"]
 }
-
-if (Boolean.getBoolean("build.jakarta.transformer.enabled") && gradle.startParameter.taskNames.contains("clean")) {
-	gradle.beforeProject {
-		delete new File(rootDir.parentFile, "build/_jakarta-transformer")
-	}
-}


### PR DESCRIPTION
This is an update for [LPD-49291](https://liferay.atlassian.net/browse/LPD-49291).

`ant all` passed locally with a large number of modules being transformed.