### PR TITLE
LPD-54754 Help with jar publication for Jakarta

### DIFF
--- a/modules/build-jakarta-transformer.gradle
+++ b/modules/build-jakarta-transformer.gradle
@@ -38,11 +38,8 @@ task jarTransformed
 
 jar {
 	enabled = true
-	finalizedBy jarTransformed
 	setActions([])
-}
 
-jarTransformed {
 	doLast {
 		JakartaTransformerCLI jakartaTransformerCLI = new JakartaTransformerCLI(System.out, System.out, new String[] {configurations.compileOnly.singleFile, jar.archivePath})
 
@@ -60,6 +57,4 @@ jarTransformed {
 
 		JarTransformer.transform(jar.archivePath)
 	}
-
-	mustRunAfter generatePomFileForMavenPublication
 }

--- a/modules/third-party/org-springframework-test/build.gradle
+++ b/modules/third-party/org-springframework-test/build.gradle
@@ -1,3 +1,9 @@
+afterEvaluate {
+	publish {
+		enabled = true
+	}
+}
+
 apply from: "../../build-jakarta-transformer.gradle"
 
 dependencies {


### PR DESCRIPTION
This is an update for [LPD-54754](https://liferay.atlassian.net/browse/LPD-54754).

@shuyangzhou will you please double-check the second commit? I adjusted the `modules/build-jakarta-transformer.gradle` file so that we are just modifying the `jar` task, that way the task dependency graph stays the same for publish and cache tasks. 

@brianchandotcom order really matterns for the change to `modules/build-jakarta-transformer.gradle`. The `doLast` statement _must come after_ the `setActions` statement, it will break if we sort alphabetically.