### PR TITLE
LPD-54953 Deactivate consistently failing tests

### DIFF
--- a/modules/sdk/gradle-plugins-app-docker/src/gradleTest/smoke/sample-test/src/test/java/com/example/sample/internal/GreetingBuilderImplTest.java
+++ b/modules/sdk/gradle-plugins-app-docker/src/gradleTest/smoke/sample-test/src/test/java/com/example/sample/internal/GreetingBuilderImplTest.java
@@ -8,6 +8,7 @@ package com.example.sample.internal;
 import com.example.sample.GreetingBuilder;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -15,6 +16,7 @@ import org.junit.Test;
  */
 public class GreetingBuilderImplTest {
 
+	@Ignore
 	@Test
 	public void testGetHello() {
 		GreetingBuilder greetingBuilder = new GreetingBuilderImpl("World");

--- a/modules/sdk/gradle-plugins-test-integration/src/gradleTest/smoke/src/testIntegration/java/com/example/sample/GreetingBuilderTest.java
+++ b/modules/sdk/gradle-plugins-test-integration/src/gradleTest/smoke/src/testIntegration/java/com/example/sample/GreetingBuilderTest.java
@@ -7,6 +7,7 @@ package com.example.sample;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -19,6 +20,7 @@ public class GreetingBuilderTest {
 		_greetingBuilder = new GreetingBuilder("World");
 	}
 
+	@Ignore
 	@Test
 	public void testGetGoodbye() {
 		Assert.assertEquals("Goodbye World", _greetingBuilder.getGoodbye());

--- a/modules/sdk/project-templates/project-templates-control-menu-entry/src/test/java/com/liferay/project/templates/control/menu/entry/ProjectTemplatesControlMenuEntryTest.java
+++ b/modules/sdk/project-templates/project-templates-control-menu-entry/src/test/java/com/liferay/project/templates/control/menu/entry/ProjectTemplatesControlMenuEntryTest.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,6 +71,7 @@ public class ProjectTemplatesControlMenuEntryTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateControlMenuEntry() throws Exception {
 		String template = "control-menu-entry";

--- a/modules/sdk/project-templates/project-templates-layout-template/src/test/java/com/liferay/project/templates/layout/template/ProjectTemplatesLayoutTemplatesTest.java
+++ b/modules/sdk/project-templates/project-templates-layout-template/src/test/java/com/liferay/project/templates/layout/template/ProjectTemplatesLayoutTemplatesTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -65,6 +66,7 @@ public class ProjectTemplatesLayoutTemplatesTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateLayoutTemplate() throws Exception {
 		String template = "layout-template";

--- a/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletCustomPackageTest.java
+++ b/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletCustomPackageTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -69,6 +70,7 @@ public class ProjectTemplatesMVCPortletCustomPackageTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateMVCPortlet() throws Exception {
 		File gradleProjectDir = testBuildTemplatePortlet(

--- a/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletNameTest.java
+++ b/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletNameTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -69,6 +70,7 @@ public class ProjectTemplatesMVCPortletNameTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateMVCPortlet() throws Exception {
 		File gradleProjectDir = testBuildTemplatePortlet(

--- a/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletSuffixTest.java
+++ b/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletSuffixTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -69,6 +70,7 @@ public class ProjectTemplatesMVCPortletSuffixTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateMVCPortlet() throws Exception {
 		File gradleProjectDir = testBuildTemplatePortlet(

--- a/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletTest.java
+++ b/modules/sdk/project-templates/project-templates-mvc-portlet/src/test/java/com/liferay/project/templates/mvc/portlet/ProjectTemplatesMVCPortletTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -69,6 +70,7 @@ public class ProjectTemplatesMVCPortletTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateMVCPortlet() throws Exception {
 		File gradleProjectDir = testBuildTemplatePortlet(

--- a/modules/sdk/project-templates/project-templates-npm-react-portlet/src/test/java/com/liferay/project/templates/npm/react/portlet/ProjectTemplatesNpmReactPortletTest.java
+++ b/modules/sdk/project-templates/project-templates-npm-react-portlet/src/test/java/com/liferay/project/templates/npm/react/portlet/ProjectTemplatesNpmReactPortletTest.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -83,6 +84,7 @@ public class ProjectTemplatesNpmReactPortletTest
 		_nodePackageManager = nodePackageManager;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateNpmReactPortlet() throws Exception {
 		String template = "npm-react-portlet";

--- a/modules/sdk/project-templates/project-templates-npm-vuejs-portlet/src/test/java/com/liferay/project/templates/npm/vuejs/portlet/ProjectTemplatesNpmVuejsPortletTest.java
+++ b/modules/sdk/project-templates/project-templates-npm-vuejs-portlet/src/test/java/com/liferay/project/templates/npm/vuejs/portlet/ProjectTemplatesNpmVuejsPortletTest.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -83,6 +84,7 @@ public class ProjectTemplatesNpmVuejsPortletTest
 		_nodePackageManager = nodePackageManager;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateNpmVuejsPortlet() throws Exception {
 		String template = "npm-vuejs-portlet";

--- a/modules/sdk/project-templates/project-templates-panel-app/src/test/java/com/liferay/project/templates/panel/app/ProjectTemplatesPanelAppTest.java
+++ b/modules/sdk/project-templates/project-templates-panel-app/src/test/java/com/liferay/project/templates/panel/app/ProjectTemplatesPanelAppTest.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,6 +71,7 @@ public class ProjectTemplatesPanelAppTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplatePanelApp() throws Exception {
 		String template = "panel-app";

--- a/modules/sdk/project-templates/project-templates-portlet-configuration-icon/src/test/java/com/liferay/project/templates/portlet/configuration/icon/ProjectTemplatesPortletConfigurationIconTest.java
+++ b/modules/sdk/project-templates/project-templates-portlet-configuration-icon/src/test/java/com/liferay/project/templates/portlet/configuration/icon/ProjectTemplatesPortletConfigurationIconTest.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,6 +71,7 @@ public class ProjectTemplatesPortletConfigurationIconTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplatePortletConfigurationIcon() throws Exception {
 		String template = "portlet-configuration-icon";

--- a/modules/sdk/project-templates/project-templates-portlet-provider/src/test/java/com/liferay/project/templates/portlet/provider/ProjectTemplatesPortletProviderTest.java
+++ b/modules/sdk/project-templates/project-templates-portlet-provider/src/test/java/com/liferay/project/templates/portlet/provider/ProjectTemplatesPortletProviderTest.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,6 +71,7 @@ public class ProjectTemplatesPortletProviderTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplatePortletProvider() throws Exception {
 		String template = "portlet-provider";

--- a/modules/sdk/project-templates/project-templates-portlet-toolbar-contributor/src/test/java/com/liferay/project/templates/portlet/toolbar/contributor/ProjectTemplatesPortletToolbarContributorTest.java
+++ b/modules/sdk/project-templates/project-templates-portlet-toolbar-contributor/src/test/java/com/liferay/project/templates/portlet/toolbar/contributor/ProjectTemplatesPortletToolbarContributorTest.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,6 +71,7 @@ public class ProjectTemplatesPortletToolbarContributorTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplatePortletToolbarContributor() throws Exception {
 		String template = "portlet-toolbar-contributor";

--- a/modules/sdk/project-templates/project-templates-rest-builder/src/test/java/com/liferay/project/templates/rest/builder/ProjectTemplatesRESTBuilderWorkspaceTest.java
+++ b/modules/sdk/project-templates/project-templates-rest-builder/src/test/java/com/liferay/project/templates/rest/builder/ProjectTemplatesRESTBuilderWorkspaceTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Callable;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -112,6 +113,7 @@ public class ProjectTemplatesRESTBuilderWorkspaceTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateRESTBuilderWorkspace() throws Exception {
 		String template = "rest-builder";

--- a/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/test/java/com/liferay/project/templates/simulation/panel/entry/ProjectTemplatesSimulationPanelEntryTest.java
+++ b/modules/sdk/project-templates/project-templates-simulation-panel-entry/src/test/java/com/liferay/project/templates/simulation/panel/entry/ProjectTemplatesSimulationPanelEntryTest.java
@@ -21,6 +21,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -70,6 +71,7 @@ public class ProjectTemplatesSimulationPanelEntryTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateSimulationPanelEntry() throws Exception {
 		String template = "simulation-panel-entry";

--- a/modules/sdk/project-templates/project-templates-theme/src/test/java/com/liferay/project/templates/theme/ProjectTemplatesThemeTest.java
+++ b/modules/sdk/project-templates/project-templates-theme/src/test/java/com/liferay/project/templates/theme/ProjectTemplatesThemeTest.java
@@ -18,6 +18,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -62,6 +63,7 @@ public class ProjectTemplatesThemeTest implements BaseProjectTemplatesTestCase {
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateTheme() throws Exception {
 		String template = "theme";

--- a/modules/sdk/project-templates/project-templates-war-hook/src/test/java/com/liferay/project/templates/war/hook/ProjectTemplatesWarHookTest.java
+++ b/modules/sdk/project-templates/project-templates-war-hook/src/test/java/com/liferay/project/templates/war/hook/ProjectTemplatesWarHookTest.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -65,6 +66,7 @@ public class ProjectTemplatesWarHookTest
 		_liferayVersion = liferayVersion;
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateWarHook() throws Exception {
 		String template = "war-hook";

--- a/modules/sdk/project-templates/project-templates-workspace/src/test/java/com/liferay/project/templates/workspace/ProjectTemplatesWorkspaceTest.java
+++ b/modules/sdk/project-templates/project-templates-workspace/src/test/java/com/liferay/project/templates/workspace/ProjectTemplatesWorkspaceTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -56,6 +57,7 @@ public class ProjectTemplatesWorkspaceTest
 		_gradleDistribution = URI.create(gradleDistribution);
 	}
 
+	@Ignore
 	@Test
 	public void testBuildTemplateWorkspace() throws Exception {
 		File workspaceProjectDir = buildWorkspace(
@@ -320,6 +322,7 @@ public class ProjectTemplatesWorkspaceTest
 		testExists(mavenModulesDir, "foo-portlet/target/foo-portlet-1.0.0.jar");
 	}
 
+	@Ignore
 	@Test
 	public void testCompareAntBndPluginVersions() throws Exception {
 		Assume.assumeTrue(isBuildProjects());
@@ -374,6 +377,7 @@ public class ProjectTemplatesWorkspaceTest
 				"<version>" + gradleAntBndVersion);
 	}
 
+	@Ignore
 	@Test
 	public void testComparePortalToolsBundleSupportPluginVersions()
 		throws Exception {

--- a/modules/util/osgi-bundle-builder/src/test/java/com/liferay/osgi/bundle/builder/commands/OSGiBundleBuilderCommandTest.java
+++ b/modules/util/osgi-bundle-builder/src/test/java/com/liferay/osgi/bundle/builder/commands/OSGiBundleBuilderCommandTest.java
@@ -30,6 +30,7 @@ import java.util.zip.ZipFile;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -78,6 +79,7 @@ public class OSGiBundleBuilderCommandTest {
 		_compareJarDirs(_expectedDir, actualDir);
 	}
 
+	@Ignore
 	@Test
 	public void testManifestCommand() throws Exception {
 		ManifestCommand manifestCommand = new ManifestCommand();


### PR DESCRIPTION
Hi team,
The tests in this PR have been consistently failing in the Acceptance test suite.

If these are lower priority tests that will not be fixed in the near future it might be best to deactivate for now so it's not adding noise to test results or using up CI resources. For more information, please see this [Slack post](https://liferay.slack.com/archives/C0251HKT0K0/p1747027740422599).

If these tests are being monitored or passing elsewhere please let the Release team know in #t-release on Slack so we can exclude these from Acceptance instead of deactivating them.

Lastely, if everything looks good, please forward. Thanks!