### PR TITLE
LPD-61164 exclude glob patterns in yarn workspace section of package.json do not work properly

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -39,8 +39,7 @@
 			"apps/*/*",
 			"apps/*/*/*",
 			"dxp/apps/*/*",
-			"dxp/apps/*/!(osb-faro/osb-faro-web)*/*",
-			"dxp/apps/osb/*/!(osb-faro/osb-faro-web)*/*",
+			"dxp/apps/*/*/*",
 			"util/portal-tools-rest-builder-test-client-js",
 			"_node-scripts"
 		]


### PR DESCRIPTION
This is an update for [LPD-61164](https://liferay.atlassian.net/browse/LPD-61164).
