### PR TITLE
LPD-62507 YMLRESTConfigFileBreakingChangeCommitMessageCheck should not require a message when a module is only being added

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRESTConfigFileBreakingChangeCommitMessageCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/YMLRESTConfigFileBreakingChangeCommitMessageCheck.java
@@ -77,6 +77,10 @@ public class YMLRESTConfigFileBreakingChangeCommitMessageCheck
 				}
 			}
 
+			if (oldCompatibilityVersion == null) {
+				continue;
+			}
+
 			return !StringUtil.equals(
 				newCompatibilityVersion, oldCompatibilityVersion);
 		}


### PR DESCRIPTION
This is an update for [LPD-62507](https://liferay.atlassian.net/browse/LPD-62507).

@ling-alan-huang