### PR TITLE
LPD-62514 source-formatter: avoids many consecutive newlines

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesPortalFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesPortalFileCheck.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -338,12 +339,28 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 			}
 		}
 
-		String newContent = StringBundler.concat(
-			_generateProperties(portalPropertiesMap), "\n\n",
-			_generateProperties(propertiesMap), "\n\n",
-			_generateProperties(portalOSGiEnvironmentPropertiesMap));
+		StringBundler sb = new StringBundler(6);
 
-		newContent = StringUtil.replace(newContent, "\n\n\n", "\n\n");
+		for (Map<String, List<String>> map :
+				Arrays.asList(
+					portalPropertiesMap, propertiesMap,
+					portalOSGiEnvironmentPropertiesMap)) {
+
+			if (map.isEmpty()) {
+				continue;
+			}
+
+			String propertiesString = _generateProperties(map);
+
+			if (Validator.isBlank(propertiesString)) {
+				continue;
+			}
+
+			sb.append(propertiesString);
+			sb.append("\n\n");
+		}
+
+		String newContent = StringUtil.replace(sb.toString(), "\n\n\n", "\n\n");
 
 		newContent = newContent.trim();
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesPortalFileCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesPortalFileCheck.java
@@ -59,7 +59,8 @@ public class PropertiesPortalFileCheck extends BaseFileCheck {
 			 !shortFileName.equals("portal-upgrade-ext.properties")) ||
 			(!isPortalSource() && !isSubrepository() &&
 			 (shortFileName.equals("portal.properties") ||
-			  shortFileName.equals("portal-ext.properties")))) {
+			  shortFileName.equals("portal-ext.properties"))) ||
+			shortFileName.equals("IncorrectOrderingCheck.properties")) {
 
 			content = _sortPortalProperties(absolutePath, content);
 

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/PropertiesSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/PropertiesSourceProcessorTest.java
@@ -15,6 +15,11 @@ import org.junit.Test;
 public class PropertiesSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
+	public void testIncorrectOrderingCheck() throws Exception {
+		test("IncorrectOrderingCheck.testproperties");
+	}
+
+	@Test
 	public void testIncorrectWhitespaceCheck() throws Exception {
 		test("IncorrectWhitespaceCheck.testproperties");
 	}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectOrderingCheck.testproperties
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/IncorrectOrderingCheck.testproperties
@@ -1,0 +1,4 @@
+configuration.override.com.liferay.captcha.configuration.CaptchaConfiguration_maxChallenges=I"1"
+
+feature.flag.LPD-17564=true
+feature.flag.LPD-21926=true

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/IncorrectOrderingCheck.testproperties
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/IncorrectOrderingCheck.testproperties
@@ -1,0 +1,4 @@
+feature.flag.LPD-17564=true
+feature.flag.LPD-21926=true
+
+configuration.override.com.liferay.captcha.configuration.CaptchaConfiguration_maxChallenges=I"1"


### PR DESCRIPTION
This is an update for [LPD-62514](https://liferay.atlassian.net/browse/LPD-62514).

@ling-alan-huang this one could be solved a couple of ways:

1. The method I used here, which conditionally appends content
2. Changing the `StringUtil.replace(newContent, "\n\n\n", "\n\n");` statement to be a regex replace, something like: 
```java
newContent.replaceAll("\n{3,}", "\n\n")
```
3. Both?

I wasn't certain whether that newline replace statement was suppose to already cover this case, so I left it. If it's redundant, then we can just change one statement and remove the other. Please let me know whether there are any other things I might be missing here.

Thanks!

---

Edit - one more question:
I had to add a manual exception for the test file [here](https://github.com/liferay-devtools/liferay-portal/pull/551/files#diff-1e479fec6aba0cafd9ef6d0ef57fa3df7be50f4e73ae6a74294709a9aec5b735R64). It seems strange, is there a better way to do that?