### PR TITLE
LPD-65248 SF, preserve original code style when parsing Java to build JavaTerm for customers since they disable JavaParser 

### DIFF
--- a/modules/apps/static/portal-file-install/portal-file-install-api/src/main/java/com/liferay/portal/file/install/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-api/src/main/java/com/liferay/portal/file/install/properties/ConfigurationHandler.java
@@ -525,6 +525,7 @@ public class ConfigurationHandler {
 	private static final int _TOKEN_VAL_OPEN = '"'; // '{';
 
 	private static final Map<Integer, Class<?>> _codeToType = new HashMap<>();
+
 	private static final Map<Class<?>, Integer> _typeToCode =
 		HashMapBuilder.<Class<?>, Integer>put(
 			Boolean.class, _TOKEN_BOOLEAN

--- a/modules/apps/static/portal-file-install/portal-file-install-api/src/main/java/com/liferay/portal/file/install/properties/ConfigurationHandler.java
+++ b/modules/apps/static/portal-file-install/portal-file-install-api/src/main/java/com/liferay/portal/file/install/properties/ConfigurationHandler.java
@@ -525,7 +525,6 @@ public class ConfigurationHandler {
 	private static final int _TOKEN_VAL_OPEN = '"'; // '{';
 
 	private static final Map<Integer, Class<?>> _codeToType = new HashMap<>();
-
 	private static final Map<Class<?>, Integer> _typeToCode =
 		HashMapBuilder.<Class<?>, Integer>put(
 			Boolean.class, _TOKEN_BOOLEAN

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
@@ -45,6 +45,13 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 
 		String content = javaTerm.getContent();
 
+		if (!content.contains("new ActionableDynamicQuery.AddCriteriaMethod") &&
+			!content.contains(
+				"new ActionableDynamicQuery.PerformActionMethod")) {
+
+			return content;
+		}
+
 		File file = new File(absolutePath);
 
 		FileText fileText = new FileText(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
@@ -40,7 +40,7 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 		String content = javaTerm.getContent();
 
 		List<JavaClass> anonymousClasses =
-			JavaClassParser.parseAnonymousClasses(content);
+			JavaClassParser.parseAnonymousClasses(fileName, fileContent);
 
 		if (anonymousClasses.isEmpty()) {
 			return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
@@ -9,12 +9,18 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.tools.ToolsUtil;
+import com.liferay.source.formatter.checkstyle.util.CheckstyleUtil;
 import com.liferay.source.formatter.parser.JavaClass;
 import com.liferay.source.formatter.parser.JavaClassParser;
 import com.liferay.source.formatter.parser.JavaMethod;
 import com.liferay.source.formatter.parser.JavaParameter;
 import com.liferay.source.formatter.parser.JavaSignature;
 import com.liferay.source.formatter.parser.JavaTerm;
+
+import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.FileText;
+
+import java.io.File;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +45,16 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 
 		String content = javaTerm.getContent();
 
+		File file = new File(absolutePath);
+
+		FileText fileText = new FileText(
+			file, CheckstyleUtil.getLines(fileContent));
+
+		FileContents fileContents = new FileContents(fileText);
+
 		List<JavaClass> anonymousClasses =
-			JavaClassParser.parseAnonymousClasses(fileName, fileContent);
+			JavaClassParser.parseAnonymousClasses(
+				fileName, fileContent, fileContents);
 
 		if (anonymousClasses.isEmpty()) {
 			return content;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
@@ -63,10 +63,6 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 			JavaClassParser.parseAnonymousClasses(
 				fileName, fileContent, fileContents);
 
-		if (anonymousClasses.isEmpty()) {
-			return content;
-		}
-
 		for (JavaClass anonymousClass : anonymousClasses) {
 			content = _convertToLambda(
 				fileName, content, anonymousClass, javaTerm,

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaAnonymousInnerClassCheck.java
@@ -9,18 +9,11 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.tools.ToolsUtil;
-import com.liferay.source.formatter.checkstyle.util.CheckstyleUtil;
 import com.liferay.source.formatter.parser.JavaClass;
-import com.liferay.source.formatter.parser.JavaClassParser;
 import com.liferay.source.formatter.parser.JavaMethod;
 import com.liferay.source.formatter.parser.JavaParameter;
 import com.liferay.source.formatter.parser.JavaSignature;
 import com.liferay.source.formatter.parser.JavaTerm;
-
-import com.puppycrawl.tools.checkstyle.api.FileContents;
-import com.puppycrawl.tools.checkstyle.api.FileText;
-
-import java.io.File;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,61 +36,49 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 			String fileContent)
 		throws Exception {
 
-		String content = javaTerm.getContent();
+		JavaClass javaClass = (JavaClass)javaTerm;
 
-		if (!content.contains("new ActionableDynamicQuery.AddCriteriaMethod") &&
-			!content.contains(
-				"new ActionableDynamicQuery.PerformActionMethod")) {
-
-			return content;
+		if (!javaClass.isAnonymous()) {
+			return javaTerm.getContent();
 		}
 
-		File file = new File(absolutePath);
+		JavaMethod parentJavaMethod = javaTerm.getParentJavaMethod();
 
-		FileText fileText = new FileText(
-			file, CheckstyleUtil.getLines(fileContent));
-
-		FileContents fileContents = new FileContents(fileText);
-
-		List<JavaClass> anonymousClasses =
-			JavaClassParser.parseAnonymousClasses(
-				fileName, fileContent, fileContents);
-
-		for (JavaClass anonymousClass : anonymousClasses) {
-			content = _convertToLambda(
-				fileName, content, anonymousClass, javaTerm,
-				"ActionableDynamicQuery.AddCriteriaMethod", false);
-			content = _convertToLambda(
-				fileName, content, anonymousClass, javaTerm,
-				"ActionableDynamicQuery.PerformActionMethod", true);
+		if (parentJavaMethod == null) {
+			return javaTerm.getContent();
 		}
 
-		return content;
+		String anonymousClassContent = javaTerm.getContent();
+
+		anonymousClassContent = _convertToLambda(
+			fileName, anonymousClassContent, javaClass, parentJavaMethod,
+			"ActionableDynamicQuery.AddCriteriaMethod", false);
+
+		return _convertToLambda(
+			fileName, anonymousClassContent, javaClass, parentJavaMethod,
+			"ActionableDynamicQuery.PerformActionMethod", true);
 	}
 
 	@Override
 	protected String[] getCheckableJavaTermNames() {
-		return new String[] {JAVA_CONSTRUCTOR, JAVA_METHOD};
+		return new String[] {JAVA_CLASS};
 	}
 
 	private String _convertToLambda(
-			String fileName, String content, JavaClass anonymousClass,
-			JavaTerm javaTerm, String className, boolean useParameterType)
-		throws Exception {
-
-		String anonymousClassContent = anonymousClass.getContent();
+		String fileName, String anonymousClassContent, JavaClass anonymousClass,
+		JavaTerm javaTerm, String className, boolean useParameterType) {
 
 		if (!StringUtil.startsWith(
 				StringUtil.removeChars(anonymousClassContent, '\n', '\t'),
 				"new " + className)) {
 
-			return content;
+			return anonymousClassContent;
 		}
 
 		List<JavaTerm> javaTerms = anonymousClass.getChildJavaTerms();
 
 		if (javaTerms.size() != 1) {
-			return content;
+			return anonymousClassContent;
 		}
 
 		JavaTerm anonymousClassJavaTerm = javaTerms.get(0);
@@ -105,7 +86,7 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 		if (!anonymousClassJavaTerm.hasAnnotation("Override") ||
 			!(anonymousClassJavaTerm instanceof JavaMethod)) {
 
-			return content;
+			return anonymousClassContent;
 		}
 
 		JavaMethod anonymousClassJavaMethod =
@@ -115,7 +96,7 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 				fileName, anonymousClassContent, anonymousClassJavaMethod,
 				javaTerm)) {
 
-			return content;
+			return anonymousClassContent;
 		}
 
 		int x = anonymousClassContent.indexOf("{\n");
@@ -128,14 +109,14 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 			anonymousClassJavaMethod.getContent(), "\n", lastLine);
 
 		if (!expectedContent.equals(anonymousClassContent)) {
-			return content;
+			return anonymousClassContent;
 		}
 
 		String methodBody = _getMethodBody(
 			anonymousClassJavaMethod.getContent());
 
 		if (methodBody == null) {
-			return content;
+			return anonymousClassContent;
 		}
 
 		StringBundler sb = new StringBundler(5);
@@ -148,8 +129,7 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 		sb.append("\n");
 		sb.append(lastLine);
 
-		return StringUtil.replace(
-			content, anonymousClassContent, sb.toString());
+		return sb.toString();
 	}
 
 	private String _getLambdaSignature(
@@ -241,7 +221,9 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 		int x = javaTermContent.indexOf(anonymousClassContent);
 
 		for (String variableName : variableNames) {
-			if (!_isDuplicateName(javaTerm, variableName, x)) {
+			if (!_isDuplicateName(
+					anonymousClassJavaMethod, javaTerm, variableName, x)) {
+
 				continue;
 			}
 
@@ -257,7 +239,9 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 		}
 
 		for (String parameterName : parameterNames) {
-			if (!_isDuplicateName(javaTerm, parameterName, x)) {
+			if (!_isDuplicateName(
+					anonymousClassJavaMethod, javaTerm, parameterName, x)) {
+
 				continue;
 			}
 
@@ -276,7 +260,28 @@ public class JavaAnonymousInnerClassCheck extends BaseJavaTermCheck {
 	}
 
 	private boolean _isDuplicateName(
-		JavaTerm javaTerm, String variableName, int end) {
+		JavaMethod anonymousClassJavaMethod, JavaTerm javaTerm,
+		String variableName, int end) {
+
+		JavaClass javaClass = anonymousClassJavaMethod.getParentJavaClass();
+
+		while (true) {
+			JavaClass parentJavaClass = javaClass.getParentJavaClass();
+
+			if (parentJavaClass == null) {
+				break;
+			}
+
+			javaClass = parentJavaClass;
+		}
+
+		for (JavaTerm childJavaTerm : javaClass.getChildJavaTerms()) {
+			if (childJavaTerm.getLineNumber() == javaTerm.getLineNumber()) {
+				javaTerm = childJavaTerm;
+
+				break;
+			}
+		}
 
 		JavaSignature signature = javaTerm.getSignature();
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
@@ -133,7 +133,7 @@ public class SourceChecksUtil {
 
 						anonymousClasses =
 							JavaClassParser.parseAnonymousClasses(
-								sourceChecksResult.getContent(),
+								fileName, sourceChecksResult.getContent(),
 								javaClass.getPackageName(),
 								javaClass.getImportNames());
 					}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
@@ -144,8 +144,8 @@ public class SourceChecksUtil {
 						FileContents fileContents = new FileContents(fileText);
 
 						javaClass = JavaClassParser.parseJavaClass(
-							fileName, sourceChecksResult.getContent(),
-							detailAST, fileContents);
+							sourceChecksResult.getContent(), detailAST,
+							fileContents);
 
 						anonymousClasses =
 							JavaClassParser.parseAnonymousClasses(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
@@ -36,6 +36,7 @@ import com.liferay.source.formatter.util.SourceFormatterUtil;
 
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 import java.io.File;
@@ -140,16 +141,18 @@ public class SourceChecksUtil {
 
 						DetailAST detailAST = JavaParser.parseFileText(
 							fileText, JavaParser.Options.WITH_COMMENTS);
+						FileContents fileContents = new FileContents(fileText);
 
 						javaClass = JavaClassParser.parseJavaClass(
 							fileName, sourceChecksResult.getContent(),
-							detailAST);
+							detailAST, fileContents);
 
 						anonymousClasses =
 							JavaClassParser.parseAnonymousClasses(
 								fileName, sourceChecksResult.getContent(),
 								javaClass.getPackageName(),
-								javaClass.getImportNames(), detailAST);
+								javaClass.getImportNames(), detailAST,
+								fileContents);
 					}
 					catch (ParseException parseException) {
 						sourceChecksResult.addSourceFormatterMessage(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/util/SourceChecksUtil.java
@@ -22,6 +22,7 @@ import com.liferay.source.formatter.check.configuration.SourceCheckConfiguration
 import com.liferay.source.formatter.check.configuration.SourceChecksResult;
 import com.liferay.source.formatter.check.configuration.SourceFormatterConfiguration;
 import com.liferay.source.formatter.check.configuration.SourceFormatterSuppressions;
+import com.liferay.source.formatter.checkstyle.util.CheckstyleUtil;
 import com.liferay.source.formatter.parser.GradleFile;
 import com.liferay.source.formatter.parser.GradleFileParser;
 import com.liferay.source.formatter.parser.JavaClass;
@@ -32,6 +33,10 @@ import com.liferay.source.formatter.util.CheckType;
 import com.liferay.source.formatter.util.DebugUtil;
 import com.liferay.source.formatter.util.SourceFormatterCheckUtil;
 import com.liferay.source.formatter.util.SourceFormatterUtil;
+
+import com.puppycrawl.tools.checkstyle.JavaParser;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileText;
 
 import java.io.File;
 
@@ -128,14 +133,23 @@ public class SourceChecksUtil {
 
 				if (javaClass == null) {
 					try {
+						file = new File(absolutePath);
+
+						FileText fileText = new FileText(
+							file, CheckstyleUtil.getLines(content));
+
+						DetailAST detailAST = JavaParser.parseFileText(
+							fileText, JavaParser.Options.WITH_COMMENTS);
+
 						javaClass = JavaClassParser.parseJavaClass(
-							fileName, sourceChecksResult.getContent());
+							fileName, sourceChecksResult.getContent(),
+							detailAST);
 
 						anonymousClasses =
 							JavaClassParser.parseAnonymousClasses(
 								fileName, sourceChecksResult.getContent(),
 								javaClass.getPackageName(),
-								javaClass.getImportNames());
+								javaClass.getImportNames(), detailAST);
 					}
 					catch (ParseException parseException) {
 						sourceChecksResult.addSourceFormatterMessage(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/BaseJavaTerm.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/BaseJavaTerm.java
@@ -84,6 +84,11 @@ public abstract class BaseJavaTerm implements JavaTerm {
 	}
 
 	@Override
+	public JavaMethod getParentJavaMethod() {
+		return _parentJavaMethod;
+	}
+
+	@Override
 	public JavaSignature getSignature() {
 		return null;
 	}
@@ -205,6 +210,11 @@ public abstract class BaseJavaTerm implements JavaTerm {
 		_parentJavaClass = javaClass;
 	}
 
+	@Override
+	public void setParentJavaMethod(JavaMethod javaMethod) {
+		_parentJavaMethod = javaMethod;
+	}
+
 	private final String _accessModifier;
 	private final String _content;
 	private final boolean _isAbstract;
@@ -213,5 +223,6 @@ public abstract class BaseJavaTerm implements JavaTerm {
 	private final int _lineNumber;
 	private final String _name;
 	private JavaClass _parentJavaClass;
+	private JavaMethod _parentJavaMethod;
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -5,56 +5,109 @@
 
 package com.liferay.source.formatter.parser;
 
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.tools.ToolsUtil;
 import com.liferay.source.formatter.check.util.JavaSourceUtil;
 import com.liferay.source.formatter.check.util.SourceUtil;
+import com.liferay.source.formatter.checkstyle.util.CheckstyleUtil;
+import com.liferay.source.formatter.checkstyle.util.DetailASTUtil;
 
+import com.puppycrawl.tools.checkstyle.JavaParser;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.FileText;
+import com.puppycrawl.tools.checkstyle.api.FullIdent;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+import java.io.File;
 import java.io.IOException;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Hugo Huijser
  */
 public class JavaClassParser {
 
-	public static List<JavaClass> parseAnonymousClasses(String content)
+	public static List<JavaClass> parseAnonymousClasses(
+			String fileName, String content)
 		throws IOException, ParseException {
 
-		return parseAnonymousClasses(content, null, Collections.emptyList());
+		return parseAnonymousClasses(
+			fileName, content, null, Collections.emptyList());
 	}
 
 	public static List<JavaClass> parseAnonymousClasses(
-			String content, String packageName, List<String> importNames)
+			String fileName, String content, String packageName,
+			List<String> importNames)
 		throws IOException, ParseException {
+
+		String absolutePath = SourceUtil.getAbsolutePath(fileName);
+
+		File file = new File(absolutePath);
+
+		FileText fileText = new FileText(
+			file, CheckstyleUtil.getLines(content));
+
+		FileContents fileContents = new FileContents(fileText);
+
+		DetailAST rootDetailAST;
+
+		try {
+			rootDetailAST = JavaParser.parseFileText(
+				fileText, JavaParser.Options.WITH_COMMENTS);
+		}
+		catch (CheckstyleException checkstyleException) {
+			throw new RuntimeException(checkstyleException);
+		}
+
+		DetailAST siblingDetailAST = rootDetailAST.getNextSibling();
+
+		while (true) {
+			if ((siblingDetailAST == null) ||
+				(siblingDetailAST.getType() == TokenTypes.CLASS_DEF) ||
+				(siblingDetailAST.getType() == TokenTypes.ENUM_DEF) ||
+				(siblingDetailAST.getType() == TokenTypes.INTERFACE_DEF)) {
+
+				break;
+			}
+
+			siblingDetailAST = siblingDetailAST.getNextSibling();
+		}
+
+		if (siblingDetailAST == null) {
+			return Collections.emptyList();
+		}
 
 		List<JavaClass> anonymousClasses = new ArrayList<>();
 
-		Matcher matcher = _anonymousClassPattern.matcher(content);
+		List<DetailAST> leteralNewDetailASTList =
+			DetailASTUtil.getAllChildTokens(
+				siblingDetailAST, true, TokenTypes.LITERAL_NEW);
 
-		while (matcher.find()) {
-			String anonymousClassContent = _getAnonymousClassContent(
-				content, matcher.start() + 1,
-				StringUtil.equals(matcher.group(1), "<"));
+		for (DetailAST leteralNewDetailAST : leteralNewDetailASTList) {
+			DetailAST objBlockDetailAST = leteralNewDetailAST.findFirstToken(
+				TokenTypes.OBJBLOCK);
 
-			if (anonymousClassContent != null) {
-				anonymousClasses.add(
-					_parseJavaClass(
-						JavaTerm.ACCESS_MODIFIER_PRIVATE, true,
-						anonymousClassContent,
-						SourceUtil.getLineNumber(content, matcher.start()),
-						StringPool.BLANK, importNames, false, false, false,
-						false, false, false, false, packageName, false));
+			if (objBlockDetailAST == null) {
+				continue;
 			}
+
+			String classContent = _getJavaTermContent(
+				fileContents, leteralNewDetailAST);
+
+			classContent = classContent.substring(0, classContent.length() - 1);
+
+			JavaClass anonymousClass = _parseJavaClass(
+				JavaTerm.ACCESS_MODIFIER_PRIVATE, true, classContent,
+				leteralNewDetailAST.getLineNo(), StringPool.BLANK, importNames,
+				false, false, false, false, false, false, packageName, false,
+				fileContents, leteralNewDetailAST);
+
+			anonymousClasses.add(anonymousClass);
 		}
 
 		return anonymousClasses;
@@ -63,443 +116,457 @@ public class JavaClassParser {
 	public static JavaClass parseJavaClass(String fileName, String content)
 		throws IOException, ParseException {
 
-		String className = JavaSourceUtil.getClassName(fileName);
+		String absolutePath = SourceUtil.getAbsolutePath(fileName);
 
-		Pattern pattern = Pattern.compile(
-			StringBundler.concat(
-				"\n(public\\s+)?(abstract\\s+)?(final\\s+)?@?",
-				"(strictfp\\s+)?((non-)?sealed\\s+)?(class|enum|interface|",
-				"record)\\s+", className,
-				"(\\s*\\(.*?\\))?([<|\\s][^\\{]*)\\{"));
+		File file = new File(absolutePath);
 
-		Matcher matcher = pattern.matcher(content);
+		FileText fileText = new FileText(
+			file, CheckstyleUtil.getLines(content));
 
-		if (!matcher.find()) {
-			throw new ParseException("Parsing error");
+		FileContents fileContents = new FileContents(fileText);
+
+		DetailAST rootDetailAST;
+
+		try {
+			rootDetailAST = JavaParser.parseFileText(
+				fileText, JavaParser.Options.WITH_COMMENTS);
+		}
+		catch (CheckstyleException checkstyleException) {
+			throw new RuntimeException(checkstyleException);
 		}
 
-		int x = matcher.start() + 1;
-
-		int y = x + 1;
+		DetailAST siblingDetailAST = rootDetailAST.getNextSibling();
 
 		while (true) {
-			y = content.lastIndexOf("\n\n", y - 1);
+			if ((siblingDetailAST == null) ||
+				(siblingDetailAST.getType() == TokenTypes.ANNOTATION_DEF) ||
+				(siblingDetailAST.getType() == TokenTypes.CLASS_DEF) ||
+				(siblingDetailAST.getType() == TokenTypes.ENUM_DEF) ||
+				(siblingDetailAST.getType() == TokenTypes.INTERFACE_DEF)) {
 
-			if (y == -1) {
-				throw new ParseException("Parsing error");
-			}
-
-			if (ToolsUtil.getLevel(content.substring(y, x)) == 0) {
 				break;
 			}
+
+			siblingDetailAST = siblingDetailAST.getNextSibling();
 		}
 
-		int lineNumber = SourceUtil.getLineNumber(content, y + 2);
+		DetailAST modifiersDetailAST = siblingDetailAST.findFirstToken(
+			TokenTypes.MODIFIERS);
 
-		String classContent = content.substring(y + 2);
+		String accessModifier = JavaTerm.ACCESS_MODIFIER_DEFAULT;
+
+		if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_PRIVATE)) {
+			accessModifier = JavaTerm.ACCESS_MODIFIER_PRIVATE;
+		}
+		else if (modifiersDetailAST.branchContains(
+					TokenTypes.LITERAL_PROTECTED)) {
+
+			accessModifier = JavaTerm.ACCESS_MODIFIER_PROTECTED;
+		}
+		else if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_PUBLIC)) {
+			accessModifier = JavaTerm.ACCESS_MODIFIER_PUBLIC;
+		}
 
 		boolean isAbstract = false;
-
-		if (matcher.group(2) != null) {
-			isAbstract = true;
-		}
-
-		boolean isEnum = false;
-
 		boolean isFinal = false;
-
-		if (matcher.group(3) != null) {
-			isFinal = true;
-		}
-
 		boolean isStrictfp = false;
-
-		if (matcher.group(4) != null) {
-			isStrictfp = true;
-		}
-
 		boolean nonsealed = false;
 		boolean sealed = false;
 
-		String s = matcher.group(5);
+		if (modifiersDetailAST.branchContains(TokenTypes.ABSTRACT)) {
+			isAbstract = true;
+		}
 
-		if (s != null) {
-			s = s.trim();
+		if (modifiersDetailAST.branchContains(TokenTypes.FINAL)) {
+			isFinal = true;
+		}
 
-			if (s.equals("sealed")) {
-				sealed = true;
-			}
-			else {
-				nonsealed = true;
-			}
+		if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_NON_SEALED)) {
+			nonsealed = true;
+		}
+
+		if (modifiersDetailAST.branchContains(TokenTypes.STRICTFP)) {
+			isStrictfp = true;
+		}
+
+		if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_SEALED)) {
+			sealed = true;
 		}
 
 		boolean isInterface = false;
 
-		if (matcher.group(7) != null) {
-			String token = matcher.group(7);
-
-			if (token.equals("enum")) {
-				isEnum = true;
-			}
-			else if (token.equals("interface")) {
-				isInterface = true;
-			}
+		if (siblingDetailAST.getType() == TokenTypes.INTERFACE_DEF) {
+			isInterface = true;
 		}
 
-		JavaClass javaClass = _parseJavaClass(
-			JavaTerm.ACCESS_MODIFIER_PUBLIC, false, classContent, lineNumber,
-			className, JavaSourceUtil.getImportNames(content), isAbstract,
-			isEnum, isFinal, isInterface, false, isStrictfp, nonsealed,
-			JavaSourceUtil.getPackageName(content), sealed);
+		DetailAST nameDetailAST = siblingDetailAST.findFirstToken(
+			TokenTypes.IDENT);
 
-		return _parseExtendsImplementsPermits(
-			javaClass, StringUtil.trim(matcher.group(9)));
+		String className = nameDetailAST.getText();
+
+		String classContent = _getJavaTermContent(
+			fileContents, siblingDetailAST);
+
+		JavaClass javaClass = _parseJavaClass(
+			accessModifier, false, classContent, siblingDetailAST.getLineNo(),
+			className, JavaSourceUtil.getImportNames(content), isAbstract,
+			isFinal, isInterface, false, isStrictfp, nonsealed,
+			JavaSourceUtil.getPackageName(content), sealed, fileContents,
+			siblingDetailAST);
+
+		_parseExtendsImplementsPermits(javaClass, siblingDetailAST);
+
+		return javaClass;
 	}
 
-	private static String _getAnonymousClassContent(
-		String content, int start, boolean genericClass) {
+	private static Position _getEndPosition(DetailAST detailAST)
+		throws ParseException {
 
-		int x = start;
+		if ((detailAST.getType() == TokenTypes.ANNOTATION_DEF) ||
+			(detailAST.getType() == TokenTypes.CLASS_DEF) ||
+			(detailAST.getType() == TokenTypes.ENUM_DEF) ||
+			(detailAST.getType() == TokenTypes.INTERFACE_DEF) ||
+			(detailAST.getType() == TokenTypes.LITERAL_NEW)) {
 
-		if (genericClass) {
-			while (true) {
-				x = content.indexOf('>', x + 1);
+			DetailAST objBlockDetailAST = detailAST.findFirstToken(
+				TokenTypes.OBJBLOCK);
 
-				if (x == -1) {
+			if (objBlockDetailAST == null) {
+				return null;
+			}
+
+			DetailAST lastChildDetailAST = objBlockDetailAST.getLastChild();
+
+			if ((lastChildDetailAST == null) ||
+				(lastChildDetailAST.getType() != TokenTypes.RCURLY)) {
+
+				return null;
+			}
+
+			return new Position(
+				lastChildDetailAST.getColumnNo(),
+				lastChildDetailAST.getLineNo());
+		}
+
+		if (detailAST.getType() == TokenTypes.STATIC_INIT) {
+			DetailAST slistBlockDetailAST = detailAST.findFirstToken(
+				TokenTypes.SLIST);
+
+			if (slistBlockDetailAST == null) {
+				return null;
+			}
+
+			DetailAST lastChildDetailAST = slistBlockDetailAST.getLastChild();
+
+			if ((lastChildDetailAST == null) ||
+				(lastChildDetailAST.getType() != TokenTypes.RCURLY)) {
+
+				return null;
+			}
+
+			return new Position(
+				lastChildDetailAST.getColumnNo(),
+				lastChildDetailAST.getLineNo());
+		}
+
+		if (detailAST.getType() == TokenTypes.VARIABLE_DEF) {
+			DetailAST lastChildDetailAST = detailAST.getLastChild();
+
+			if ((lastChildDetailAST == null) ||
+				(lastChildDetailAST.getType() != TokenTypes.SEMI)) {
+
+				return null;
+			}
+
+			return new Position(
+				lastChildDetailAST.getColumnNo(),
+				lastChildDetailAST.getLineNo());
+		}
+
+		if ((detailAST.getType() == TokenTypes.CTOR_DEF) ||
+			(detailAST.getType() == TokenTypes.METHOD_DEF)) {
+
+			DetailAST lastChildDetailAST = detailAST.getLastChild();
+
+			if (lastChildDetailAST == null) {
+				return null;
+			}
+
+			if (lastChildDetailAST.getType() == TokenTypes.SLIST) {
+				lastChildDetailAST = lastChildDetailAST.getLastChild();
+
+				if ((lastChildDetailAST == null) ||
+					(lastChildDetailAST.getType() != TokenTypes.RCURLY)) {
+
 					return null;
 				}
 
-				int level = ToolsUtil.getLevel(
-					content.substring(start, x + 1), "<", ">");
-
-				if (level == 0) {
-					break;
-				}
+				return new Position(
+					lastChildDetailAST.getColumnNo(),
+					lastChildDetailAST.getLineNo());
+			}
+			else if (lastChildDetailAST.getType() == TokenTypes.SEMI) {
+				return new Position(
+					lastChildDetailAST.getColumnNo(),
+					lastChildDetailAST.getLineNo());
 			}
 
-			if (!Objects.equals(content.charAt(x + 1), '(')) {
-				return null;
-			}
-		}
-
-		while (true) {
-			x = content.indexOf(')', x + 1);
-
-			if (x == -1) {
-				return null;
-			}
-
-			if (ToolsUtil.getLevel(content.substring(start, x + 1), "(", ")") ==
-					0) {
-
-				break;
-			}
-		}
-
-		String s = StringUtil.trim(content.substring(x + 1));
-
-		if (!s.startsWith("{\n")) {
 			return null;
-		}
-
-		while (true) {
-			x = content.indexOf('}', x + 1);
-
-			if (x == -1) {
-				return null;
-			}
-
-			String anonymousClassContent = content.substring(start, x + 1);
-
-			if (ToolsUtil.getLevel(anonymousClassContent, "{", "}") == 0) {
-				return anonymousClassContent;
-			}
-		}
-	}
-
-	private static String _getClassName(String line) {
-		int pos = line.indexOf(" extends ");
-
-		if (pos == -1) {
-			pos = line.indexOf(" implements ");
-		}
-
-		if (pos == -1) {
-			pos = line.indexOf(CharPool.OPEN_CURLY_BRACE);
-		}
-
-		if (pos != -1) {
-			line = line.substring(0, pos);
-		}
-
-		pos = line.indexOf(CharPool.LESS_THAN);
-
-		if (pos != -1) {
-			line = line.substring(0, pos);
-		}
-
-		line = line.trim();
-
-		pos = line.lastIndexOf(CharPool.SPACE);
-
-		return line.substring(pos + 1);
-	}
-
-	private static int _getCommentEndLineNumber(
-		String classContent, int lineNumber) {
-
-		while (true) {
-			String line = SourceUtil.getLine(classContent, lineNumber);
-
-			if (line.endsWith("*/")) {
-				return lineNumber;
-			}
-
-			lineNumber++;
-		}
-	}
-
-	private static String _getConstructorOrMethodName(String line) {
-		int x = line.lastIndexOf(CharPool.SPACE);
-
-		return line.substring(x + 1);
-	}
-
-	private static JavaTerm _getJavaTerm(
-			String packageName, List<String> importNames, String metadata,
-			String javaTermContent, int lineNumber)
-		throws IOException, ParseException {
-
-		Matcher matcher1 = _javaTermStartLinePattern.matcher(javaTermContent);
-
-		if (!matcher1.find()) {
-			return null;
-		}
-
-		String startLine = StringUtil.trim(matcher1.group());
-
-		int x = startLine.indexOf(CharPool.OPEN_PARENTHESIS);
-
-		if (x != -1) {
-			startLine = startLine.substring(0, x);
-		}
-
-		startLine = StringUtil.replace(
-			startLine, new String[] {"\t", "\n", " synchronized "},
-			new String[] {"", " ", " "});
-
-		startLine = startLine.replaceAll(" {2,}", " ");
-
-		javaTermContent = metadata + javaTermContent;
-
-		if (startLine.startsWith("static {")) {
-			return new JavaStaticBlock(javaTermContent, lineNumber);
-		}
-
-		String accessModifier = JavaTerm.ACCESS_MODIFIER_DEFAULT;
-
-		for (String curAccessModifier : JavaTerm.ACCESS_MODIFIERS) {
-			if (startLine.startsWith(curAccessModifier)) {
-				accessModifier = curAccessModifier;
-
-				break;
-			}
-		}
-
-		boolean isAbstract = SourceUtil.containsUnquoted(
-			startLine, " abstract ");
-		boolean isEnum = SourceUtil.containsUnquoted(startLine, " enum ");
-		boolean isFinal = SourceUtil.containsUnquoted(startLine, " final ");
-		boolean isInterface = SourceUtil.containsUnquoted(
-			startLine, " interface ");
-		boolean isStatic = SourceUtil.containsUnquoted(startLine, " static ");
-
-		int y = startLine.indexOf(CharPool.EQUAL);
-
-		if (SourceUtil.containsUnquoted(startLine, " @interface ") ||
-			SourceUtil.containsUnquoted(startLine, " class ") ||
-			SourceUtil.containsUnquoted(startLine, " enum ") ||
-			SourceUtil.containsUnquoted(startLine, " interface ")) {
-
-			JavaClass javaClass = _parseJavaClass(
-				accessModifier, false, javaTermContent, lineNumber,
-				_getClassName(startLine), importNames, isAbstract, isEnum,
-				isFinal, isInterface, isStatic, false, false, packageName,
-				false);
-
-			Pattern pattern = Pattern.compile(
-				StringBundler.concat(
-					"\\s(class|enum|interface)\\s+", javaClass.getName(),
-					"([<|\\s][^\\{]*)\\{"));
-
-			Matcher matcher2 = pattern.matcher(javaTermContent);
-
-			if (matcher2.find()) {
-				javaClass = _parseExtendsImplementsPermits(
-					javaClass, matcher2.group(2));
-			}
-
-			return javaClass;
-		}
-
-		if (((y > 0) && ((x == -1) || (x > y))) ||
-			(startLine.endsWith(StringPool.SEMICOLON) && (x == -1))) {
-
-			return new JavaVariable(
-				accessModifier, javaTermContent, isAbstract, isFinal, isStatic,
-				lineNumber, _getVariableName(startLine));
-		}
-
-		int spaceCount = StringUtil.count(startLine, CharPool.SPACE);
-
-		if (x == -1) {
-			if (!accessModifier.equals(JavaTerm.ACCESS_MODIFIER_PUBLIC) ||
-				(spaceCount != 2)) {
-
-				return null;
-			}
-
-			return new JavaConstructor(
-				accessModifier, javaTermContent, isAbstract, isFinal, isStatic,
-				lineNumber, _getConstructorOrMethodName(startLine));
-		}
-
-		if (isStatic || (spaceCount > 1) ||
-			(accessModifier.equals(JavaTerm.ACCESS_MODIFIER_DEFAULT) &&
-			 (spaceCount > 0))) {
-
-			return new JavaMethod(
-				accessModifier, javaTermContent, isAbstract, isFinal, isStatic,
-				lineNumber, _getConstructorOrMethodName(startLine));
-		}
-
-		if ((spaceCount == 1) ||
-			(accessModifier.equals(JavaTerm.ACCESS_MODIFIER_DEFAULT) &&
-			 (spaceCount == 0))) {
-
-			return new JavaConstructor(
-				accessModifier, javaTermContent, isAbstract, isFinal, isStatic,
-				lineNumber, _getConstructorOrMethodName(startLine));
 		}
 
 		return null;
 	}
 
-	private static int _getJavaTermEndLineNumber(
-		String classContent, int lineNumber) {
+	private static JavaTerm _getJavaTerm(
+			String packageName, List<String> importNames,
+			String javaTermContent, DetailAST detailAST,
+			FileContents fileContents)
+		throws IOException, ParseException {
 
-		int x = SourceUtil.getLineStartPos(classContent, lineNumber);
+		String accessModifier = JavaTerm.ACCESS_MODIFIER_DEFAULT;
+		boolean isAbstract = false;
+		boolean isFinal = false;
 
-		String s = classContent.substring(x);
+		boolean isInterface = false;
 
-		Matcher matcher = _javaTermEndPattern.matcher(s);
+		if (detailAST.getType() == TokenTypes.INTERFACE_DEF) {
+			isInterface = true;
+		}
 
-		while (matcher.find()) {
-			String javaTermContent = s.substring(0, matcher.end());
+		DetailAST modifiersDetailAST = detailAST.findFirstToken(
+			TokenTypes.MODIFIERS);
 
-			if ((ToolsUtil.getLevel(javaTermContent, "(", ")") == 0) &&
-				(ToolsUtil.getLevel(javaTermContent, "{", "}") == 0)) {
+		if (modifiersDetailAST != null) {
+			if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_PRIVATE)) {
+				accessModifier = JavaTerm.ACCESS_MODIFIER_PRIVATE;
+			}
+			else if (modifiersDetailAST.branchContains(
+						TokenTypes.LITERAL_PROTECTED)) {
 
-				return lineNumber + StringUtil.count(javaTermContent, "\n") - 1;
+				accessModifier = JavaTerm.ACCESS_MODIFIER_PROTECTED;
+			}
+			else if (modifiersDetailAST.branchContains(
+						TokenTypes.LITERAL_PUBLIC)) {
+
+				accessModifier = JavaTerm.ACCESS_MODIFIER_PUBLIC;
 			}
 		}
 
-		return -1;
-	}
+		boolean isStatic = false;
+		boolean isStrictfp = false;
+		boolean nonsealed = false;
+		boolean sealed = false;
 
-	private static int _getMatchingEndLineNumber(
-		String classContent, int lineNumber, String increaseLevelString,
-		String decreaseLevelString) {
-
-		int level = 0;
-
-		while (true) {
-			level += ToolsUtil.getLevel(
-				SourceUtil.getLine(classContent, lineNumber),
-				increaseLevelString, decreaseLevelString);
-
-			if (level == 0) {
-				return lineNumber;
+		if (modifiersDetailAST != null) {
+			if (modifiersDetailAST.branchContains(TokenTypes.ABSTRACT)) {
+				isAbstract = true;
 			}
 
-			lineNumber++;
+			if (modifiersDetailAST.branchContains(TokenTypes.FINAL)) {
+				isFinal = true;
+			}
+
+			if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_STATIC)) {
+				isStatic = true;
+			}
+
+			if (modifiersDetailAST.branchContains(
+					TokenTypes.LITERAL_NON_SEALED)) {
+
+				nonsealed = true;
+			}
+
+			if (modifiersDetailAST.branchContains(TokenTypes.STRICTFP)) {
+				isStrictfp = true;
+			}
+
+			if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_SEALED)) {
+				sealed = true;
+			}
 		}
+
+		if ((detailAST.getType() == TokenTypes.ANNOTATION_DEF) ||
+			(detailAST.getType() == TokenTypes.CLASS_DEF) ||
+			(detailAST.getType() == TokenTypes.ENUM_DEF) ||
+			(detailAST.getType() == TokenTypes.INTERFACE_DEF)) {
+
+			DetailAST nameDetailAST = detailAST.findFirstToken(
+				TokenTypes.IDENT);
+
+			String className = nameDetailAST.getText();
+
+			JavaClass javaClass = _parseJavaClass(
+				accessModifier, false, javaTermContent, detailAST.getLineNo(),
+				className, importNames, isAbstract, isFinal, isInterface,
+				isStatic, isStrictfp, nonsealed, packageName, sealed,
+				fileContents, detailAST);
+
+			_parseExtendsImplementsPermits(javaClass, detailAST);
+
+			return javaClass;
+		}
+
+		if (detailAST.getType() == TokenTypes.STATIC_INIT) {
+			return new JavaStaticBlock(javaTermContent, detailAST.getLineNo());
+		}
+
+		String name = _getName(detailAST.findFirstToken(TokenTypes.IDENT));
+
+		if (detailAST.getType() == TokenTypes.CTOR_DEF) {
+			return new JavaConstructor(
+				accessModifier, javaTermContent, isAbstract, isFinal, isStatic,
+				detailAST.getLineNo(), name);
+		}
+
+		if (detailAST.getType() == TokenTypes.METHOD_DEF) {
+			return new JavaMethod(
+				accessModifier, javaTermContent, isAbstract, isFinal, isStatic,
+				detailAST.getLineNo(), name);
+		}
+
+		if (detailAST.getType() == TokenTypes.VARIABLE_DEF) {
+			return new JavaVariable(
+				accessModifier, javaTermContent, isAbstract, isFinal, isStatic,
+				detailAST.getLineNo(), name);
+		}
+
+		return null;
 	}
 
-	private static String _getVariableName(String line) {
-		int x = line.indexOf(CharPool.EQUAL);
-		int y = line.lastIndexOf(CharPool.SPACE);
-
-		if (x != -1) {
-			line = line.substring(0, x);
-			line = StringUtil.trim(line);
-
-			y = line.lastIndexOf(CharPool.SPACE);
-
-			return line.substring(y + 1);
-		}
-
-		if (line.endsWith(StringPool.SEMICOLON)) {
-			return line.substring(y + 1, line.length() - 1);
-		}
-
-		return StringPool.BLANK;
-	}
-
-	private static JavaClass _parseExtendsImplementsPermits(
-			JavaClass javaClass, String s)
+	private static String _getJavaTermContent(
+			FileContents fileContents, DetailAST detailAST)
 		throws ParseException {
 
-		if (ToolsUtil.getLevel(s, "<", ">") != 0) {
-			throw new ParseException("Parsing error around class declaration");
+		Position endPosition = _getEndPosition(detailAST);
+
+		if (endPosition == null) {
+			throw new ParseException(
+				"Parsing error at line \"" + detailAST.getLineNo() + "\"");
 		}
 
-		outerLoop:
-		while (true) {
-			int x = s.indexOf("<");
+		Position startPosition = new Position(
+			detailAST.getColumnNo(), _getStartLineNumber(detailAST));
 
-			if (x == -1) {
+		String javaTermContent = _getJavaTermContent(
+			fileContents, startPosition, endPosition);
+
+		if (startPosition.getColumnNumber() != 0) {
+			javaTermContent = javaTermContent + "\n";
+		}
+
+		return javaTermContent;
+	}
+
+	private static String _getJavaTermContent(
+			FileContents fileContents, Position startPosition,
+			Position endPosition)
+		throws ParseException {
+
+		int endLineNumber = endPosition.getLineNumber();
+		int startLineNumber = startPosition.getLineNumber();
+
+		if (endLineNumber == startLineNumber) {
+			String line = fileContents.getLine(startLineNumber - 1);
+
+			return line.substring(0, endPosition.getColumnNumber() + 1);
+		}
+
+		StringBundler sb = new StringBundler();
+
+		sb.append(fileContents.getLine(startLineNumber - 1));
+		sb.append("\n");
+
+		for (int i = startLineNumber + 1; i <= (endLineNumber - 1); i++) {
+			sb.append(fileContents.getLine(i - 1));
+			sb.append("\n");
+		}
+
+		String line = fileContents.getLine(endLineNumber - 1);
+
+		sb.append(line.substring(0, endPosition.getColumnNumber() + 1));
+
+		return sb.toString();
+	}
+
+	private static String _getName(DetailAST detailAST) {
+		if (detailAST.getType() == TokenTypes.IDENT) {
+			return detailAST.getText();
+		}
+		else if (detailAST.getType() == TokenTypes.DOT) {
+			FullIdent fullIdent = FullIdent.createFullIdent(detailAST);
+
+			return fullIdent.getText();
+		}
+
+		return null;
+	}
+
+	private static String[] _getNames(DetailAST detailAST) {
+		List<String> names = new ArrayList<>();
+
+		DetailAST childDetailAST = detailAST.getFirstChild();
+
+		while (true) {
+			if (childDetailAST == null) {
 				break;
 			}
 
-			int y = x;
+			String name = _getName(childDetailAST);
 
-			while (true) {
-				y = s.indexOf(">", y + 1);
+			if (name != null) {
+				names.add(_getName(childDetailAST));
+			}
 
-				if (ToolsUtil.getLevel(s.substring(x, y + 1), "<", ">") == 0) {
-					s = StringUtil.trim(s.substring(0, x) + s.substring(y + 1));
+			childDetailAST = childDetailAST.getNextSibling();
+		}
 
-					continue outerLoop;
-				}
+		return names.toArray(new String[0]);
+	}
+
+	private static int _getStartLineNumber(DetailAST detailAST) {
+		int startLineNumber = detailAST.getLineNo();
+
+		List<DetailAST> childDetailASTList = DetailASTUtil.getAllChildTokens(
+			detailAST, true, DetailASTUtil.ALL_TYPES);
+
+		for (DetailAST childDetailAST : childDetailASTList) {
+			if (childDetailAST.getLineNo() < startLineNumber) {
+				startLineNumber = childDetailAST.getLineNo();
 			}
 		}
 
-		Matcher matcher = _permitsPattern.matcher(s);
+		return startLineNumber;
+	}
 
-		if (matcher.find()) {
-			javaClass.addPermittedClassNames(
-				StringUtil.split(s.substring(matcher.end())));
+	private static JavaClass _parseExtendsImplementsPermits(
+		JavaClass javaClass, DetailAST detailAST) {
 
-			s = s.substring(0, matcher.start());
+		DetailAST extendsClauseDetailAST = detailAST.findFirstToken(
+			TokenTypes.EXTENDS_CLAUSE);
+
+		if (extendsClauseDetailAST != null) {
+			String[] extendedClassNames = _getNames(extendsClauseDetailAST);
+
+			javaClass.addExtendedClassNames(extendedClassNames);
 		}
 
-		s = StringUtil.trim(s);
+		DetailAST implementsClauseDetailAST = detailAST.findFirstToken(
+			TokenTypes.IMPLEMENTS_CLAUSE);
 
-		matcher = _implementsPattern.matcher(s);
+		if (implementsClauseDetailAST != null) {
+			String[] implementedClassNames = _getNames(
+				implementsClauseDetailAST);
 
-		if (matcher.find()) {
-			javaClass.addImplementedClassNames(
-				StringUtil.split(s.substring(matcher.end())));
-
-			s = s.substring(0, matcher.start());
+			javaClass.addImplementedClassNames(implementedClassNames);
 		}
 
-		s = StringUtil.trim(s);
+		DetailAST permitsClauseDetailAST = detailAST.findFirstToken(
+			TokenTypes.PERMITS_CLAUSE);
 
-		if (s.startsWith("extends")) {
-			javaClass.addExtendedClassNames(StringUtil.split(s.substring(7)));
+		if (permitsClauseDetailAST != null) {
+			String[] permitsClassNames = _getNames(permitsClauseDetailAST);
+
+			javaClass.addPermittedClassNames(permitsClassNames);
 		}
 
 		return javaClass;
@@ -508,145 +575,66 @@ public class JavaClassParser {
 	private static JavaClass _parseJavaClass(
 			String accessModifier, boolean anonymous, String classContent,
 			int classLineNumber, String className, List<String> importNames,
-			boolean isAbstract, boolean isEnum, boolean isFinal,
-			boolean isInterface, boolean isStatic, boolean isStrictfp,
-			boolean nonsealed, String packageName, boolean sealed)
+			boolean isAbstract, boolean isFinal, boolean isInterface,
+			boolean isStatic, boolean isStrictfp, boolean nonsealed,
+			String packageName, boolean sealed, FileContents fileContents,
+			DetailAST detailAST)
 		throws IOException, ParseException {
+
+		DetailAST objBlockDetailAST = detailAST.findFirstToken(
+			TokenTypes.OBJBLOCK);
+
+		if (objBlockDetailAST == null) {
+			return null;
+		}
 
 		JavaClass javaClass = new JavaClass(
 			accessModifier, anonymous, classContent, importNames, isAbstract,
 			isFinal, isInterface, isStatic, isStrictfp, classLineNumber,
 			className, nonsealed, packageName, sealed);
 
-		int lineNumber = 0;
+		List<DetailAST> childDetailASTList = DetailASTUtil.getAllChildTokens(
+			objBlockDetailAST, false, TokenTypes.ANNOTATION_DEF,
+			TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.ENUM_DEF,
+			TokenTypes.INTERFACE_DEF, TokenTypes.METHOD_DEF,
+			TokenTypes.STATIC_INIT, TokenTypes.VARIABLE_DEF);
 
-		int annotationLevel = 0;
-		int level = 0;
+		for (DetailAST childDetailAST : childDetailASTList) {
+			JavaTerm javaTerm = _getJavaTerm(
+				packageName, importNames,
+				_getJavaTermContent(fileContents, childDetailAST),
+				childDetailAST, fileContents);
 
-		if (classContent.startsWith("/*")) {
-			while (true) {
-				String line = SourceUtil.getLine(classContent, ++lineNumber);
-
-				if (line.endsWith("*/")) {
-					break;
-				}
+			if (javaTerm == null) {
+				throw new ParseException(
+					"Parsing error at line \"" + childDetailAST.getLineNo() +
+						"\"");
 			}
+
+			javaClass.addChildJavaTerm(javaTerm);
 		}
 
-		while (true) {
-			String line = SourceUtil.getLine(classContent, ++lineNumber);
-
-			annotationLevel += ToolsUtil.getLevel(line);
-			level += ToolsUtil.getLevel(line, "{", "}");
-
-			if ((annotationLevel == 0) && (level != 0)) {
-				break;
-			}
-		}
-
-		if (isEnum) {
-			while (true) {
-				String line = StringUtil.trim(
-					SourceUtil.getLine(classContent, ++lineNumber));
-
-				level += ToolsUtil.getLevel(line, "{", "}");
-
-				if (level == 0) {
-					return javaClass;
-				}
-
-				if (line.endsWith(";") && (level == 1)) {
-					break;
-				}
-			}
-		}
-
-		int javaTermLineNumber = -1;
-
-		while (true) {
-			String line = StringUtil.trim(
-				SourceUtil.getLine(classContent, ++lineNumber));
-
-			if ((line == null) || line.equals("}")) {
-				return javaClass;
-			}
-
-			if (line.equals(StringPool.BLANK) || line.startsWith("//")) {
-				continue;
-			}
-
-			if (line.equals("/*") || line.matches("/\\*[^*].*")) {
-				lineNumber = _getCommentEndLineNumber(classContent, lineNumber);
-
-				continue;
-			}
-
-			if (line.equals("{")) {
-				lineNumber = _getMatchingEndLineNumber(
-					classContent, lineNumber, "{", "}");
-
-				continue;
-			}
-
-			if (javaTermLineNumber == -1) {
-				javaTermLineNumber = lineNumber;
-			}
-
-			if (line.startsWith("@")) {
-				lineNumber = _getMatchingEndLineNumber(
-					classContent, lineNumber, "(", ")");
-			}
-			else if (line.startsWith("/**")) {
-				lineNumber = _getCommentEndLineNumber(classContent, lineNumber);
-			}
-			else {
-				int x = SourceUtil.getLineStartPos(
-					classContent, javaTermLineNumber);
-				int y = SourceUtil.getLineStartPos(classContent, lineNumber);
-
-				String metadata = classContent.substring(x, y);
-
-				int javaTermEndLineNumber = _getJavaTermEndLineNumber(
-					classContent, lineNumber);
-
-				if (javaTermEndLineNumber == -1) {
-					throw new ParseException(
-						"Parsing error at line \"" + StringUtil.trim(line) +
-							"\"");
-				}
-
-				int z = SourceUtil.getLineStartPos(
-					classContent, javaTermEndLineNumber + 1);
-
-				String javaTermContent = classContent.substring(y, z);
-
-				JavaTerm javaTerm = _getJavaTerm(
-					packageName, importNames, metadata, javaTermContent,
-					classLineNumber + javaTermLineNumber - 1);
-
-				if (javaTerm == null) {
-					throw new ParseException(
-						"Parsing error at line \"" + StringUtil.trim(line) +
-							"\"");
-				}
-
-				javaClass.addChildJavaTerm(javaTerm);
-
-				javaTermLineNumber = -1;
-				lineNumber = javaTermEndLineNumber;
-			}
-		}
+		return javaClass;
 	}
 
-	private static final Pattern _anonymousClassPattern = Pattern.compile(
-		"\\snew [\\w\\.\t\n]+(\\(|\\<)");
-	private static final Pattern _implementsPattern = Pattern.compile(
-		"(\\A|\\s)implements\\s");
-	private static final Pattern _javaTermEndPattern = Pattern.compile(
-		"[;}]\\s*?\n");
-	private static final Pattern _javaTermStartLinePattern = Pattern.compile(
-		".*?[{;]\\s*?\n", Pattern.DOTALL);
-	private static final Pattern _permitsPattern = Pattern.compile(
-		"(\\A|\\s)permits\\s");
+	private static class Position {
+
+		public Position(int columnNumber, int lineNumber) {
+			_columnNumber = columnNumber;
+			_lineNumber = lineNumber;
+		}
+
+		public int getColumnNumber() {
+			return _columnNumber;
+		}
+
+		public int getLineNumber() {
+			return _lineNumber;
+		}
+
+		private final int _columnNumber;
+		private final int _lineNumber;
+
+	}
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -150,53 +150,59 @@ public class JavaClassParser {
 			siblingDetailAST = siblingDetailAST.getNextSibling();
 		}
 
-		DetailAST modifiersDetailAST = siblingDetailAST.findFirstToken(
-			TokenTypes.MODIFIERS);
-
 		String accessModifier = JavaTerm.ACCESS_MODIFIER_DEFAULT;
-
-		if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_PRIVATE)) {
-			accessModifier = JavaTerm.ACCESS_MODIFIER_PRIVATE;
-		}
-		else if (modifiersDetailAST.branchContains(
-					TokenTypes.LITERAL_PROTECTED)) {
-
-			accessModifier = JavaTerm.ACCESS_MODIFIER_PROTECTED;
-		}
-		else if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_PUBLIC)) {
-			accessModifier = JavaTerm.ACCESS_MODIFIER_PUBLIC;
-		}
-
 		boolean isAbstract = false;
 		boolean isFinal = false;
-		boolean isStrictfp = false;
-		boolean nonsealed = false;
-		boolean sealed = false;
-
-		if (modifiersDetailAST.branchContains(TokenTypes.ABSTRACT)) {
-			isAbstract = true;
-		}
-
-		if (modifiersDetailAST.branchContains(TokenTypes.FINAL)) {
-			isFinal = true;
-		}
-
-		if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_NON_SEALED)) {
-			nonsealed = true;
-		}
-
-		if (modifiersDetailAST.branchContains(TokenTypes.STRICTFP)) {
-			isStrictfp = true;
-		}
-
-		if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_SEALED)) {
-			sealed = true;
-		}
 
 		boolean isInterface = false;
 
 		if (siblingDetailAST.getType() == TokenTypes.INTERFACE_DEF) {
 			isInterface = true;
+		}
+
+		boolean isStrictfp = false;
+		boolean nonsealed = false;
+		boolean sealed = false;
+
+		DetailAST modifiersDetailAST = siblingDetailAST.findFirstToken(
+			TokenTypes.MODIFIERS);
+
+		if (modifiersDetailAST != null) {
+			if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_PRIVATE)) {
+				accessModifier = JavaTerm.ACCESS_MODIFIER_PRIVATE;
+			}
+			else if (modifiersDetailAST.branchContains(
+						TokenTypes.LITERAL_PROTECTED)) {
+
+				accessModifier = JavaTerm.ACCESS_MODIFIER_PROTECTED;
+			}
+			else if (modifiersDetailAST.branchContains(
+						TokenTypes.LITERAL_PUBLIC)) {
+
+				accessModifier = JavaTerm.ACCESS_MODIFIER_PUBLIC;
+			}
+
+			if (modifiersDetailAST.branchContains(TokenTypes.ABSTRACT)) {
+				isAbstract = true;
+			}
+
+			if (modifiersDetailAST.branchContains(TokenTypes.FINAL)) {
+				isFinal = true;
+			}
+
+			if (modifiersDetailAST.branchContains(
+					TokenTypes.LITERAL_NON_SEALED)) {
+
+				nonsealed = true;
+			}
+
+			if (modifiersDetailAST.branchContains(TokenTypes.STRICTFP)) {
+				isStrictfp = true;
+			}
+
+			if (modifiersDetailAST.branchContains(TokenTypes.LITERAL_SEALED)) {
+				sealed = true;
+			}
 		}
 
 		DetailAST nameDetailAST = siblingDetailAST.findFirstToken(
@@ -333,6 +339,11 @@ public class JavaClassParser {
 			isInterface = true;
 		}
 
+		boolean isStatic = false;
+		boolean isStrictfp = false;
+		boolean nonsealed = false;
+		boolean sealed = false;
+
 		DetailAST modifiersDetailAST = detailAST.findFirstToken(
 			TokenTypes.MODIFIERS);
 
@@ -350,14 +361,7 @@ public class JavaClassParser {
 
 				accessModifier = JavaTerm.ACCESS_MODIFIER_PUBLIC;
 			}
-		}
 
-		boolean isStatic = false;
-		boolean isStrictfp = false;
-		boolean nonsealed = false;
-		boolean sealed = false;
-
-		if (modifiersDetailAST != null) {
 			if (modifiersDetailAST.branchContains(TokenTypes.ABSTRACT)) {
 				isAbstract = true;
 			}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -633,6 +633,46 @@ public class JavaClassParser {
 			javaClass.addChildJavaTerm(javaTerm);
 		}
 
+		if (!anonymous) {
+			return javaClass;
+		}
+
+		DetailAST parentDetailAST = detailAST.getParent();
+
+		while (parentDetailAST != null) {
+			if (parentDetailAST.getType() == TokenTypes.METHOD_DEF) {
+				break;
+			}
+
+			parentDetailAST = parentDetailAST.getParent();
+		}
+
+		if (parentDetailAST == null) {
+			throw new ParseException(
+				"Parsing error at line \"" + detailAST.getLineNo() + "\"");
+		}
+
+		String javaTermContent = _getJavaTermContent(
+			fileContents, parentDetailAST);
+
+		if (javaTermContent == null) {
+			throw new ParseException(
+				"Parsing error at line \"" + detailAST.getLineNo() + "\"");
+		}
+
+		JavaTerm javaTerm = _getJavaTerm(
+			packageName, importNames, javaTermContent, parentDetailAST,
+			fileContents);
+
+		if (javaTerm == null) {
+			throw new ParseException(
+				"Parsing error at line \"" + detailAST.getLineNo() + "\"");
+		}
+
+		JavaMethod javaMethod = (JavaMethod)javaTerm;
+
+		javaClass.setParentJavaMethod(javaMethod);
+
 		return javaClass;
 	}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -150,6 +150,11 @@ public class JavaClassParser {
 			siblingDetailAST = siblingDetailAST.getNextSibling();
 		}
 
+		if (siblingDetailAST == null) {
+			throw new ParseException(
+				"Parsing error at line \"" + rootDetailAST.getLineNo() + "\"");
+		}
+
 		String accessModifier = JavaTerm.ACCESS_MODIFIER_DEFAULT;
 		boolean isAbstract = false;
 		boolean isFinal = false;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -114,33 +114,8 @@ public class JavaClassParser {
 		return anonymousClasses;
 	}
 
-	public static JavaClass parseJavaClass(String fileName, String content)
-		throws IOException, ParseException {
-
-		String absolutePath = SourceUtil.getAbsolutePath(fileName);
-
-		File file = new File(absolutePath);
-
-		FileText fileText = new FileText(
-			file, CheckstyleUtil.getLines(content));
-
-		DetailAST detailAST;
-
-		try {
-			detailAST = JavaParser.parseFileText(
-				fileText, JavaParser.Options.WITH_COMMENTS);
-		}
-		catch (CheckstyleException checkstyleException) {
-			throw new RuntimeException(checkstyleException);
-		}
-
-		return parseJavaClass(
-			fileName, content, detailAST, new FileContents(fileText));
-	}
-
 	public static JavaClass parseJavaClass(
-			String fileName, String content, DetailAST detailAST,
-			FileContents fileContents)
+			String content, DetailAST detailAST, FileContents fileContents)
 		throws IOException, ParseException {
 
 		DetailAST siblingDetailAST = detailAST.getNextSibling();
@@ -236,6 +211,29 @@ public class JavaClassParser {
 		_parseExtendsImplementsPermits(javaClass, siblingDetailAST);
 
 		return javaClass;
+	}
+
+	public static JavaClass parseJavaClass(String fileName, String content)
+		throws IOException, ParseException {
+
+		String absolutePath = SourceUtil.getAbsolutePath(fileName);
+
+		File file = new File(absolutePath);
+
+		FileText fileText = new FileText(
+			file, CheckstyleUtil.getLines(content));
+
+		DetailAST detailAST;
+
+		try {
+			detailAST = JavaParser.parseFileText(
+				fileText, JavaParser.Options.WITH_COMMENTS);
+		}
+		catch (CheckstyleException checkstyleException) {
+			throw new RuntimeException(checkstyleException);
+		}
+
+		return parseJavaClass(content, detailAST, new FileContents(fileText));
 	}
 
 	private static Position _getEndPosition(DetailAST detailAST) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -125,7 +125,8 @@ public class JavaClassParser {
 			   (siblingDetailAST.getType() != TokenTypes.ANNOTATION_DEF) &&
 			   (siblingDetailAST.getType() != TokenTypes.CLASS_DEF) &&
 			   (siblingDetailAST.getType() != TokenTypes.ENUM_DEF) &&
-			   (siblingDetailAST.getType() != TokenTypes.INTERFACE_DEF)) {
+			   (siblingDetailAST.getType() != TokenTypes.INTERFACE_DEF) &&
+			   (siblingDetailAST.getType() != TokenTypes.RECORD_DEF)) {
 
 			siblingDetailAST = siblingDetailAST.getNextSibling();
 		}
@@ -242,7 +243,8 @@ public class JavaClassParser {
 			(detailAST.getType() == TokenTypes.CLASS_DEF) ||
 			(detailAST.getType() == TokenTypes.ENUM_DEF) ||
 			(detailAST.getType() == TokenTypes.INTERFACE_DEF) ||
-			(detailAST.getType() == TokenTypes.LITERAL_NEW)) {
+			(detailAST.getType() == TokenTypes.LITERAL_NEW) ||
+			(detailAST.getType() == TokenTypes.RECORD_DEF)) {
 
 			DetailAST objBlockDetailAST = detailAST.findFirstToken(
 				TokenTypes.OBJBLOCK);
@@ -403,7 +405,8 @@ public class JavaClassParser {
 		if ((detailAST.getType() == TokenTypes.ANNOTATION_DEF) ||
 			(detailAST.getType() == TokenTypes.CLASS_DEF) ||
 			(detailAST.getType() == TokenTypes.ENUM_DEF) ||
-			(detailAST.getType() == TokenTypes.INTERFACE_DEF)) {
+			(detailAST.getType() == TokenTypes.INTERFACE_DEF) ||
+			(detailAST.getType() == TokenTypes.RECORD_DEF)) {
 
 			DetailAST nameDetailAST = detailAST.findFirstToken(
 				TokenTypes.IDENT);
@@ -604,7 +607,8 @@ public class JavaClassParser {
 			objBlockDetailAST, false, TokenTypes.ANNOTATION_DEF,
 			TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.ENUM_DEF,
 			TokenTypes.INTERFACE_DEF, TokenTypes.METHOD_DEF,
-			TokenTypes.STATIC_INIT, TokenTypes.VARIABLE_DEF);
+			TokenTypes.RECORD_DEF, TokenTypes.STATIC_INIT,
+			TokenTypes.VARIABLE_DEF);
 
 		for (DetailAST childDetailAST : childDetailASTList) {
 			String javaTermContent = _getJavaTermContent(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -84,6 +84,14 @@ public class JavaClassParser {
 			DetailASTUtil.getAllChildTokens(
 				siblingDetailAST, true, TokenTypes.LITERAL_NEW);
 
+		JavaClass parentJavaClass = null;
+
+		if (!leteralNewDetailASTList.isEmpty() &&
+			(siblingDetailAST.getType() == TokenTypes.CLASS_DEF)) {
+
+			parentJavaClass = parseJavaClass(content, detailAST, fileContents);
+		}
+
 		for (DetailAST leteralNewDetailAST : leteralNewDetailASTList) {
 			DetailAST objBlockDetailAST = leteralNewDetailAST.findFirstToken(
 				TokenTypes.OBJBLOCK);
@@ -107,7 +115,7 @@ public class JavaClassParser {
 				JavaTerm.ACCESS_MODIFIER_PRIVATE, true, classContent,
 				leteralNewDetailAST.getLineNo(), StringPool.BLANK, importNames,
 				false, false, false, false, false, false, packageName, false,
-				fileContents, leteralNewDetailAST);
+				fileContents, leteralNewDetailAST, parentJavaClass);
 
 			anonymousClasses.add(anonymousClass);
 		}
@@ -208,7 +216,7 @@ public class JavaClassParser {
 			nameDetailAST.getText(), JavaSourceUtil.getImportNames(content),
 			isAbstract, isFinal, isInterface, false, isStrictfp, nonsealed,
 			JavaSourceUtil.getPackageName(content), sealed, fileContents,
-			siblingDetailAST);
+			siblingDetailAST, null);
 
 		_parseExtendsImplementsPermits(javaClass, siblingDetailAST);
 
@@ -417,7 +425,7 @@ public class JavaClassParser {
 				accessModifier, false, javaTermContent, detailAST.getLineNo(),
 				className, importNames, isAbstract, isFinal, isInterface,
 				isStatic, isStrictfp, nonsealed, packageName, sealed,
-				fileContents, detailAST);
+				fileContents, detailAST, null);
 
 			_parseExtendsImplementsPermits(javaClass, detailAST);
 
@@ -588,7 +596,7 @@ public class JavaClassParser {
 			boolean isAbstract, boolean isFinal, boolean isInterface,
 			boolean isStatic, boolean isStrictfp, boolean nonsealed,
 			String packageName, boolean sealed, FileContents fileContents,
-			DetailAST detailAST)
+			DetailAST detailAST, JavaClass parentJavaClass)
 		throws IOException, ParseException {
 
 		DetailAST objBlockDetailAST = detailAST.findFirstToken(
@@ -670,6 +678,7 @@ public class JavaClassParser {
 
 		JavaMethod javaMethod = (JavaMethod)javaTerm;
 
+		javaClass.setParentJavaClass(parentJavaClass);
 		javaClass.setParentJavaMethod(javaMethod);
 
 		return javaClass;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -639,16 +639,16 @@ public class JavaClassParser {
 
 		DetailAST parentDetailAST = detailAST.getParent();
 
-		while (parentDetailAST != null) {
+		while (true) {
+			if (parentDetailAST == null) {
+				return javaClass;
+			}
+
 			if (parentDetailAST.getType() == TokenTypes.METHOD_DEF) {
 				break;
 			}
 
 			parentDetailAST = parentDetailAST.getParent();
-		}
-
-		if (parentDetailAST == null) {
-			return javaClass;
 		}
 
 		String javaTermContent = _getJavaTermContent(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -33,11 +33,12 @@ import java.util.List;
 public class JavaClassParser {
 
 	public static List<JavaClass> parseAnonymousClasses(
-			String fileName, String content)
+			String fileName, String content, FileContents fileContents)
 		throws IOException, ParseException {
 
 		return parseAnonymousClasses(
-			fileName, content, null, Collections.emptyList(), null, null);
+			fileName, content, null, Collections.emptyList(), null,
+			fileContents);
 	}
 
 	public static List<JavaClass> parseAnonymousClasses(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -66,14 +66,10 @@ public class JavaClassParser {
 
 		DetailAST siblingDetailAST = rootDetailAST.getNextSibling();
 
-		while (true) {
-			if ((siblingDetailAST == null) ||
-				(siblingDetailAST.getType() == TokenTypes.CLASS_DEF) ||
-				(siblingDetailAST.getType() == TokenTypes.ENUM_DEF) ||
-				(siblingDetailAST.getType() == TokenTypes.INTERFACE_DEF)) {
-
-				break;
-			}
+		while ((siblingDetailAST != null) &&
+			   (siblingDetailAST.getType() != TokenTypes.CLASS_DEF) &&
+			   (siblingDetailAST.getType() != TokenTypes.ENUM_DEF) &&
+			   (siblingDetailAST.getType() != TokenTypes.INTERFACE_DEF)) {
 
 			siblingDetailAST = siblingDetailAST.getNextSibling();
 		}
@@ -137,15 +133,11 @@ public class JavaClassParser {
 
 		DetailAST siblingDetailAST = rootDetailAST.getNextSibling();
 
-		while (true) {
-			if ((siblingDetailAST == null) ||
-				(siblingDetailAST.getType() == TokenTypes.ANNOTATION_DEF) ||
-				(siblingDetailAST.getType() == TokenTypes.CLASS_DEF) ||
-				(siblingDetailAST.getType() == TokenTypes.ENUM_DEF) ||
-				(siblingDetailAST.getType() == TokenTypes.INTERFACE_DEF)) {
-
-				break;
-			}
+		while ((siblingDetailAST != null) &&
+			   (siblingDetailAST.getType() != TokenTypes.ANNOTATION_DEF) &&
+			   (siblingDetailAST.getType() != TokenTypes.CLASS_DEF) &&
+			   (siblingDetailAST.getType() != TokenTypes.ENUM_DEF) &&
+			   (siblingDetailAST.getType() != TokenTypes.INTERFACE_DEF)) {
 
 			siblingDetailAST = siblingDetailAST.getNextSibling();
 		}
@@ -514,15 +506,11 @@ public class JavaClassParser {
 
 		DetailAST childDetailAST = detailAST.getFirstChild();
 
-		while (true) {
-			if (childDetailAST == null) {
-				break;
-			}
-
+		while (childDetailAST != null) {
 			String name = _getName(childDetailAST);
 
 			if (name != null) {
-				names.add(_getName(childDetailAST));
+				names.add(name);
 			}
 
 			childDetailAST = childDetailAST.getNextSibling();

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -37,12 +37,13 @@ public class JavaClassParser {
 		throws IOException, ParseException {
 
 		return parseAnonymousClasses(
-			fileName, content, null, Collections.emptyList(), null);
+			fileName, content, null, Collections.emptyList(), null, null);
 	}
 
 	public static List<JavaClass> parseAnonymousClasses(
 			String fileName, String content, String packageName,
-			List<String> importNames, DetailAST detailAST)
+			List<String> importNames, DetailAST detailAST,
+			FileContents fileContents)
 		throws IOException, ParseException {
 
 		String absolutePath = SourceUtil.getAbsolutePath(fileName);
@@ -51,8 +52,6 @@ public class JavaClassParser {
 
 		FileText fileText = new FileText(
 			file, CheckstyleUtil.getLines(content));
-
-		FileContents fileContents = new FileContents(fileText);
 
 		if (detailAST == null) {
 			try {
@@ -135,21 +134,14 @@ public class JavaClassParser {
 			throw new RuntimeException(checkstyleException);
 		}
 
-		return parseJavaClass(fileName, content, detailAST);
+		return parseJavaClass(
+			fileName, content, detailAST, new FileContents(fileText));
 	}
 
 	public static JavaClass parseJavaClass(
-			String fileName, String content, DetailAST detailAST)
+			String fileName, String content, DetailAST detailAST,
+			FileContents fileContents)
 		throws IOException, ParseException {
-
-		String absolutePath = SourceUtil.getAbsolutePath(fileName);
-
-		File file = new File(absolutePath);
-
-		FileText fileText = new FileText(
-			file, CheckstyleUtil.getLines(content));
-
-		FileContents fileContents = new FileContents(fileText);
 
 		DetailAST siblingDetailAST = detailAST.getNextSibling();
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -225,9 +225,7 @@ public class JavaClassParser {
 		return javaClass;
 	}
 
-	private static Position _getEndPosition(DetailAST detailAST)
-		throws ParseException {
-
+	private static Position _getEndPosition(DetailAST detailAST) {
 		if ((detailAST.getType() == TokenTypes.ANNOTATION_DEF) ||
 			(detailAST.getType() == TokenTypes.CLASS_DEF) ||
 			(detailAST.getType() == TokenTypes.ENUM_DEF) ||
@@ -245,41 +243,6 @@ public class JavaClassParser {
 
 			if ((lastChildDetailAST == null) ||
 				(lastChildDetailAST.getType() != TokenTypes.RCURLY)) {
-
-				return null;
-			}
-
-			return new Position(
-				lastChildDetailAST.getColumnNo(),
-				lastChildDetailAST.getLineNo());
-		}
-
-		if (detailAST.getType() == TokenTypes.STATIC_INIT) {
-			DetailAST slistBlockDetailAST = detailAST.findFirstToken(
-				TokenTypes.SLIST);
-
-			if (slistBlockDetailAST == null) {
-				return null;
-			}
-
-			DetailAST lastChildDetailAST = slistBlockDetailAST.getLastChild();
-
-			if ((lastChildDetailAST == null) ||
-				(lastChildDetailAST.getType() != TokenTypes.RCURLY)) {
-
-				return null;
-			}
-
-			return new Position(
-				lastChildDetailAST.getColumnNo(),
-				lastChildDetailAST.getLineNo());
-		}
-
-		if (detailAST.getType() == TokenTypes.VARIABLE_DEF) {
-			DetailAST lastChildDetailAST = detailAST.getLastChild();
-
-			if ((lastChildDetailAST == null) ||
-				(lastChildDetailAST.getType() != TokenTypes.SEMI)) {
 
 				return null;
 			}
@@ -319,6 +282,41 @@ public class JavaClassParser {
 			}
 
 			return null;
+		}
+
+		if (detailAST.getType() == TokenTypes.STATIC_INIT) {
+			DetailAST slistBlockDetailAST = detailAST.findFirstToken(
+				TokenTypes.SLIST);
+
+			if (slistBlockDetailAST == null) {
+				return null;
+			}
+
+			DetailAST lastChildDetailAST = slistBlockDetailAST.getLastChild();
+
+			if ((lastChildDetailAST == null) ||
+				(lastChildDetailAST.getType() != TokenTypes.RCURLY)) {
+
+				return null;
+			}
+
+			return new Position(
+				lastChildDetailAST.getColumnNo(),
+				lastChildDetailAST.getLineNo());
+		}
+
+		if (detailAST.getType() == TokenTypes.VARIABLE_DEF) {
+			DetailAST lastChildDetailAST = detailAST.getLastChild();
+
+			if ((lastChildDetailAST == null) ||
+				(lastChildDetailAST.getType() != TokenTypes.SEMI)) {
+
+				return null;
+			}
+
+			return new Position(
+				lastChildDetailAST.getColumnNo(),
+				lastChildDetailAST.getLineNo());
 		}
 
 		return null;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -648,8 +648,7 @@ public class JavaClassParser {
 		}
 
 		if (parentDetailAST == null) {
-			throw new ParseException(
-				"Parsing error at line \"" + detailAST.getLineNo() + "\"");
+			return javaClass;
 		}
 
 		String javaTermContent = _getJavaTermContent(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -37,12 +37,12 @@ public class JavaClassParser {
 		throws IOException, ParseException {
 
 		return parseAnonymousClasses(
-			fileName, content, null, Collections.emptyList());
+			fileName, content, null, Collections.emptyList(), null);
 	}
 
 	public static List<JavaClass> parseAnonymousClasses(
 			String fileName, String content, String packageName,
-			List<String> importNames)
+			List<String> importNames, DetailAST detailAST)
 		throws IOException, ParseException {
 
 		String absolutePath = SourceUtil.getAbsolutePath(fileName);
@@ -54,17 +54,17 @@ public class JavaClassParser {
 
 		FileContents fileContents = new FileContents(fileText);
 
-		DetailAST rootDetailAST;
-
-		try {
-			rootDetailAST = JavaParser.parseFileText(
-				fileText, JavaParser.Options.WITH_COMMENTS);
+		if (detailAST == null) {
+			try {
+				detailAST = JavaParser.parseFileText(
+					fileText, JavaParser.Options.WITH_COMMENTS);
+			}
+			catch (CheckstyleException checkstyleException) {
+				throw new RuntimeException(checkstyleException);
+			}
 		}
-		catch (CheckstyleException checkstyleException) {
-			throw new RuntimeException(checkstyleException);
-		}
 
-		DetailAST siblingDetailAST = rootDetailAST.getNextSibling();
+		DetailAST siblingDetailAST = detailAST.getNextSibling();
 
 		while ((siblingDetailAST != null) &&
 			   (siblingDetailAST.getType() != TokenTypes.CLASS_DEF) &&
@@ -125,19 +125,33 @@ public class JavaClassParser {
 		FileText fileText = new FileText(
 			file, CheckstyleUtil.getLines(content));
 
-		FileContents fileContents = new FileContents(fileText);
-
-		DetailAST rootDetailAST;
+		DetailAST detailAST;
 
 		try {
-			rootDetailAST = JavaParser.parseFileText(
+			detailAST = JavaParser.parseFileText(
 				fileText, JavaParser.Options.WITH_COMMENTS);
 		}
 		catch (CheckstyleException checkstyleException) {
 			throw new RuntimeException(checkstyleException);
 		}
 
-		DetailAST siblingDetailAST = rootDetailAST.getNextSibling();
+		return parseJavaClass(fileName, content, detailAST);
+	}
+
+	public static JavaClass parseJavaClass(
+			String fileName, String content, DetailAST detailAST)
+		throws IOException, ParseException {
+
+		String absolutePath = SourceUtil.getAbsolutePath(fileName);
+
+		File file = new File(absolutePath);
+
+		FileText fileText = new FileText(
+			file, CheckstyleUtil.getLines(content));
+
+		FileContents fileContents = new FileContents(fileText);
+
+		DetailAST siblingDetailAST = detailAST.getNextSibling();
 
 		while ((siblingDetailAST != null) &&
 			   (siblingDetailAST.getType() != TokenTypes.ANNOTATION_DEF) &&
@@ -150,7 +164,7 @@ public class JavaClassParser {
 
 		if (siblingDetailAST == null) {
 			throw new ParseException(
-				"Parsing error at line \"" + rootDetailAST.getLineNo() + "\"");
+				"Parsing error at line \"" + detailAST.getLineNo() + "\"");
 		}
 
 		String accessModifier = JavaTerm.ACCESS_MODIFIER_DEFAULT;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -541,7 +541,9 @@ public class JavaClassParser {
 			detailAST, true, DetailASTUtil.ALL_TYPES);
 
 		for (DetailAST childDetailAST : childDetailASTList) {
-			if (childDetailAST.getLineNo() < startLineNumber) {
+			if ((childDetailAST.getColumnNo() == detailAST.getColumnNo()) &&
+				(childDetailAST.getLineNo() < startLineNumber)) {
+
 				startLineNumber = childDetailAST.getLineNo();
 			}
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -311,7 +311,8 @@ public class JavaClassParser {
 					lastChildDetailAST.getColumnNo(),
 					lastChildDetailAST.getLineNo());
 			}
-			else if (lastChildDetailAST.getType() == TokenTypes.SEMI) {
+
+			if (lastChildDetailAST.getType() == TokenTypes.SEMI) {
 				return new Position(
 					lastChildDetailAST.getColumnNo(),
 					lastChildDetailAST.getLineNo());

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -448,7 +448,7 @@ public class JavaClassParser {
 			detailAST.getColumnNo(), _getStartLineNumber(detailAST));
 
 		String javaTermContent = _getJavaTermContent(
-			fileContents, startPosition, endPosition);
+			fileContents, endPosition, startPosition);
 
 		if (startPosition.getColumnNumber() != 0) {
 			javaTermContent = javaTermContent + "\n";
@@ -458,8 +458,8 @@ public class JavaClassParser {
 	}
 
 	private static String _getJavaTermContent(
-		FileContents fileContents, Position startPosition,
-		Position endPosition) {
+		FileContents fileContents, Position endPosition,
+		Position startPosition) {
 
 		int endLineNumber = endPosition.getLineNumber();
 		int startLineNumber = startPosition.getLineNumber();

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -461,9 +461,8 @@ public class JavaClassParser {
 	}
 
 	private static String _getJavaTermContent(
-			FileContents fileContents, Position startPosition,
-			Position endPosition)
-		throws ParseException {
+		FileContents fileContents, Position startPosition,
+		Position endPosition) {
 
 		int endLineNumber = endPosition.getLineNumber();
 		int startLineNumber = startPosition.getLineNumber();
@@ -541,7 +540,7 @@ public class JavaClassParser {
 		return startLineNumber;
 	}
 
-	private static JavaClass _parseExtendsImplementsPermits(
+	private static void _parseExtendsImplementsPermits(
 		JavaClass javaClass, DetailAST detailAST) {
 
 		DetailAST extendsClauseDetailAST = detailAST.findFirstToken(
@@ -571,8 +570,6 @@ public class JavaClassParser {
 
 			javaClass.addPermittedClassNames(permitsClassNames);
 		}
-
-		return javaClass;
 	}
 
 	private static JavaClass _parseJavaClass(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -636,6 +636,8 @@ public class JavaClassParser {
 			return javaClass;
 		}
 
+		javaClass.setParentJavaClass(parentJavaClass);
+
 		DetailAST parentDetailAST = detailAST.getParent();
 
 		while (true) {
@@ -669,7 +671,6 @@ public class JavaClassParser {
 
 		JavaMethod javaMethod = (JavaMethod)javaTerm;
 
-		javaClass.setParentJavaClass(parentJavaClass);
 		javaClass.setParentJavaMethod(javaMethod);
 
 		return javaClass;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -496,13 +496,14 @@ public class JavaClassParser {
 	}
 
 	private static String _getName(DetailAST detailAST) {
-		if (detailAST.getType() == TokenTypes.IDENT) {
-			return detailAST.getText();
-		}
-		else if (detailAST.getType() == TokenTypes.DOT) {
+		if (detailAST.getType() == TokenTypes.DOT) {
 			FullIdent fullIdent = FullIdent.createFullIdent(detailAST);
 
 			return fullIdent.getText();
+		}
+
+		if (detailAST.getType() == TokenTypes.IDENT) {
+			return detailAST.getText();
 		}
 
 		return null;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -33,15 +33,6 @@ import java.util.List;
 public class JavaClassParser {
 
 	public static List<JavaClass> parseAnonymousClasses(
-			String fileName, String content, FileContents fileContents)
-		throws IOException, ParseException {
-
-		return parseAnonymousClasses(
-			fileName, content, null, Collections.emptyList(), null,
-			fileContents);
-	}
-
-	public static List<JavaClass> parseAnonymousClasses(
 			String fileName, String content, String packageName,
 			List<String> importNames, DetailAST detailAST,
 			FileContents fileContents)

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaClassParser.java
@@ -95,6 +95,12 @@ public class JavaClassParser {
 			String classContent = _getJavaTermContent(
 				fileContents, leteralNewDetailAST);
 
+			if (classContent == null) {
+				throw new ParseException(
+					"Parsing error at line \"" +
+						leteralNewDetailAST.getLineNo() + "\"");
+			}
+
 			classContent = classContent.substring(0, classContent.length() - 1);
 
 			JavaClass anonymousClass = _parseJavaClass(
@@ -205,15 +211,19 @@ public class JavaClassParser {
 		DetailAST nameDetailAST = siblingDetailAST.findFirstToken(
 			TokenTypes.IDENT);
 
-		String className = nameDetailAST.getText();
-
 		String classContent = _getJavaTermContent(
 			fileContents, siblingDetailAST);
 
+		if (classContent == null) {
+			throw new ParseException(
+				"Parsing error at line \"" + siblingDetailAST.getLineNo() +
+					"\"");
+		}
+
 		JavaClass javaClass = _parseJavaClass(
 			accessModifier, false, classContent, siblingDetailAST.getLineNo(),
-			className, JavaSourceUtil.getImportNames(content), isAbstract,
-			isFinal, isInterface, false, isStrictfp, nonsealed,
+			nameDetailAST.getText(), JavaSourceUtil.getImportNames(content),
+			isAbstract, isFinal, isInterface, false, isStrictfp, nonsealed,
 			JavaSourceUtil.getPackageName(content), sealed, fileContents,
 			siblingDetailAST);
 
@@ -434,14 +444,12 @@ public class JavaClassParser {
 	}
 
 	private static String _getJavaTermContent(
-			FileContents fileContents, DetailAST detailAST)
-		throws ParseException {
+		FileContents fileContents, DetailAST detailAST) {
 
 		Position endPosition = _getEndPosition(detailAST);
 
 		if (endPosition == null) {
-			throw new ParseException(
-				"Parsing error at line \"" + detailAST.getLineNo() + "\"");
+			return null;
 		}
 
 		Position startPosition = new Position(
@@ -594,10 +602,18 @@ public class JavaClassParser {
 			TokenTypes.STATIC_INIT, TokenTypes.VARIABLE_DEF);
 
 		for (DetailAST childDetailAST : childDetailASTList) {
+			String javaTermContent = _getJavaTermContent(
+				fileContents, childDetailAST);
+
+			if (javaTermContent == null) {
+				throw new ParseException(
+					"Parsing error at line \"" + childDetailAST.getLineNo() +
+						"\"");
+			}
+
 			JavaTerm javaTerm = _getJavaTerm(
-				packageName, importNames,
-				_getJavaTermContent(fileContents, childDetailAST),
-				childDetailAST, fileContents);
+				packageName, importNames, javaTermContent, childDetailAST,
+				fileContents);
 
 			if (javaTerm == null) {
 				throw new ParseException(

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaTerm.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/parser/JavaTerm.java
@@ -41,6 +41,8 @@ public interface JavaTerm {
 
 	public JavaClass getParentJavaClass();
 
+	public JavaMethod getParentJavaMethod();
+
 	public JavaSignature getSignature();
 
 	public boolean hasAnnotation();
@@ -72,5 +74,7 @@ public interface JavaTerm {
 	public boolean isStatic();
 
 	public void setParentJavaClass(JavaClass javaClass);
+
+	public void setParentJavaMethod(JavaMethod javaMethod);
 
 }

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
@@ -11,7 +11,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.source.formatter.SourceFormatterArgs;
@@ -265,10 +264,29 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 		Set<String> modifiedContents = new HashSet<>();
 		Set<String> modifiedMessages = new TreeSet<>();
 
+		List<String> checkCategoryNames =
+			_sourceFormatterArgs.getCheckCategoryNames();
+
+		String originalReturnCharacter = StringPool.NEW_LINE;
+
+		if (content.contains(StringPool.RETURN_NEW_LINE)) {
+			originalReturnCharacter = StringPool.RETURN_NEW_LINE;
+		}
+		else if (content.contains(StringPool.RETURN)) {
+			originalReturnCharacter = StringPool.RETURN;
+		}
+
+		content = preFormat(
+			file, fileName, content, checkCategoryNames, modifiedMessages,
+			originalReturnCharacter);
+
 		String newContent = format(
 			file, fileName, absolutePath, content, content,
 			new ArrayList<>(_sourceChecks), modifiedContents, modifiedMessages,
 			0);
+
+		newContent = postFormat(
+			newContent, checkCategoryNames, originalReturnCharacter);
 
 		return processFormattedFile(
 			file, fileName, content, newContent, modifiedMessages);
@@ -284,23 +302,6 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 		_sourceFormatterMessagesMap.remove(fileName);
 
 		String newContent = content;
-
-		List<String> checkCategoryNames =
-			_sourceFormatterArgs.getCheckCategoryNames();
-
-		if (checkCategoryNames.contains("Styling") ||
-			(checkCategoryNames.isEmpty() &&
-			 ListUtil.isEmpty(_sourceFormatterArgs.getCheckNames()))) {
-
-			_checkUTF8(file, fileName);
-
-			newContent = StringUtil.replace(
-				newContent, StringPool.RETURN_NEW_LINE, StringPool.NEW_LINE);
-
-			if (!content.equals(newContent)) {
-				modifiedMessages.add(file.toString() + " (ReturnCharacter)");
-			}
-		}
 
 		newContent = parse(file, fileName, newContent, modifiedMessages);
 
@@ -440,7 +441,45 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 	protected void postFormat() throws Exception {
 	}
 
+	protected String postFormat(
+		String content, List<String> checkCategoryNames,
+		String originalReturnCharacter) {
+
+		if (!originalReturnCharacter.equals(StringPool.NEW_LINE) &&
+			checkCategoryNames.isEmpty() && isPortalSource()) {
+
+			return content;
+		}
+
+		return StringUtil.replace(
+			content, CharPool.NEW_LINE, originalReturnCharacter);
+	}
+
 	protected void preFormat() throws Exception {
+	}
+
+	protected String preFormat(
+			File file, String fileName, String content,
+			List<String> checkCategoryNames, Set<String> modifiedMessages,
+			String originalReturnCharacter)
+		throws Exception {
+
+		if (checkCategoryNames.isEmpty() && isPortalSource()) {
+			_checkUTF8(file, fileName);
+		}
+
+		String newContent = StringUtil.replace(
+			content, originalReturnCharacter, StringPool.NEW_LINE);
+
+		if (content.equals(newContent)) {
+			return newContent;
+		}
+
+		if (checkCategoryNames.isEmpty() && isPortalSource()) {
+			modifiedMessages.add(file.toString() + " (ReturnCharacter)");
+		}
+
+		return newContent;
 	}
 
 	protected void printError(String fileName, String message) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
@@ -517,7 +517,7 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 	protected File processFormattedFile(
 			File file, String fileName, String content, String newContent,
 			Set<String> modifiedMessages)
-		throws IOException, URISyntaxException {
+		throws IOException {
 
 		if (!content.equals(newContent)) {
 			if (_sourceFormatterArgs.isPrintErrors()) {

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
@@ -296,14 +296,10 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 
 			newContent = StringUtil.replace(
 				newContent, StringPool.RETURN_NEW_LINE, StringPool.NEW_LINE);
-		}
-		else if (checkCategoryNames.contains("Upgrade")) {
-			newContent = StringUtil.replace(
-				newContent, StringPool.RETURN_NEW_LINE, StringPool.NEW_LINE);
-		}
 
-		if (!content.equals(newContent)) {
-			modifiedMessages.add(file.toString() + " (ReturnCharacter)");
+			if (!content.equals(newContent)) {
+				modifiedMessages.add(file.toString() + " (ReturnCharacter)");
+			}
 		}
 
 		newContent = parse(file, fileName, newContent, modifiedMessages);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
@@ -441,9 +441,9 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 		List<String> checkCategoryNames =
 			_sourceFormatterArgs.getCheckCategoryNames();
 
-		if (originalReturnCharacter.equals(StringPool.NEW_LINE) &&
-			checkCategoryNames.isEmpty() &&
-			(isPortalSource() || isSubrepository())) {
+		if (checkCategoryNames.isEmpty() &&
+			(isPortalSource() || isSubrepository()) &&
+			originalReturnCharacter.equals(StringPool.NEW_LINE)) {
 
 			return content;
 		}

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
@@ -264,9 +264,6 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 		Set<String> modifiedContents = new HashSet<>();
 		Set<String> modifiedMessages = new TreeSet<>();
 
-		List<String> checkCategoryNames =
-			_sourceFormatterArgs.getCheckCategoryNames();
-
 		String originalReturnCharacter = StringPool.NEW_LINE;
 
 		if (content.contains(StringPool.RETURN_NEW_LINE)) {
@@ -277,16 +274,14 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 		}
 
 		content = preFormat(
-			file, fileName, content, checkCategoryNames, modifiedMessages,
-			originalReturnCharacter);
+			file, fileName, content, modifiedMessages, originalReturnCharacter);
 
 		String newContent = format(
 			file, fileName, absolutePath, content, content,
 			new ArrayList<>(_sourceChecks), modifiedContents, modifiedMessages,
 			0);
 
-		newContent = postFormat(
-			newContent, checkCategoryNames, originalReturnCharacter);
+		newContent = postFormat(newContent, originalReturnCharacter);
 
 		return processFormattedFile(
 			file, fileName, content, newContent, modifiedMessages);
@@ -442,8 +437,10 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 	}
 
 	protected String postFormat(
-		String content, List<String> checkCategoryNames,
-		String originalReturnCharacter) {
+		String content, String originalReturnCharacter) {
+
+		List<String> checkCategoryNames =
+			_sourceFormatterArgs.getCheckCategoryNames();
 
 		if (!originalReturnCharacter.equals(StringPool.NEW_LINE) &&
 			checkCategoryNames.isEmpty() && isPortalSource()) {
@@ -460,9 +457,11 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 
 	protected String preFormat(
 			File file, String fileName, String content,
-			List<String> checkCategoryNames, Set<String> modifiedMessages,
-			String originalReturnCharacter)
+			Set<String> modifiedMessages, String originalReturnCharacter)
 		throws Exception {
+
+		List<String> checkCategoryNames =
+			_sourceFormatterArgs.getCheckCategoryNames();
 
 		if (checkCategoryNames.isEmpty() && isPortalSource()) {
 			_checkUTF8(file, fileName);

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
@@ -273,15 +273,16 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 			originalReturnCharacter = StringPool.RETURN;
 		}
 
-		content = preFormat(
+		String preFormattedContent = preFormat(
 			file, fileName, content, modifiedMessages, originalReturnCharacter);
 
-		String newContent = format(
-			file, fileName, absolutePath, content, content,
-			new ArrayList<>(_sourceChecks), modifiedContents, modifiedMessages,
-			0);
+		preFormattedContent = format(
+			file, fileName, absolutePath, preFormattedContent,
+			preFormattedContent, new ArrayList<>(_sourceChecks),
+			modifiedContents, modifiedMessages, 0);
 
-		newContent = postFormat(newContent, originalReturnCharacter);
+		String newContent = postFormat(
+			preFormattedContent, originalReturnCharacter);
 
 		return processFormattedFile(
 			file, fileName, content, newContent, modifiedMessages);
@@ -442,8 +443,9 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 		List<String> checkCategoryNames =
 			_sourceFormatterArgs.getCheckCategoryNames();
 
-		if (!originalReturnCharacter.equals(StringPool.NEW_LINE) &&
-			checkCategoryNames.isEmpty() && isPortalSource()) {
+		if (originalReturnCharacter.equals(StringPool.NEW_LINE) &&
+			checkCategoryNames.isEmpty() &&
+			(isPortalSource() || isSubrepository())) {
 
 			return content;
 		}
@@ -463,18 +465,22 @@ public abstract class BaseSourceProcessor implements SourceProcessor {
 		List<String> checkCategoryNames =
 			_sourceFormatterArgs.getCheckCategoryNames();
 
-		if (checkCategoryNames.isEmpty() && isPortalSource()) {
+		if (checkCategoryNames.isEmpty() &&
+			(isPortalSource() || isSubrepository())) {
+
 			_checkUTF8(file, fileName);
+		}
+
+		if (originalReturnCharacter.equals(StringPool.NEW_LINE)) {
+			return content;
 		}
 
 		String newContent = StringUtil.replace(
 			content, originalReturnCharacter, StringPool.NEW_LINE);
 
-		if (content.equals(newContent)) {
-			return newContent;
-		}
+		if (checkCategoryNames.isEmpty() &&
+			(isPortalSource() || isSubrepository())) {
 
-		if (checkCategoryNames.isEmpty() && isPortalSource()) {
 			modifiedMessages.add(file.toString() + " (ReturnCharacter)");
 		}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/BaseSourceProcessor.java
@@ -36,8 +36,6 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import java.io.File;
 import java.io.IOException;
 
-import java.net.URISyntaxException;
-
 import java.nio.ByteBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/YMLSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/YMLSourceProcessor.java
@@ -12,11 +12,8 @@ import com.liferay.portal.kernel.util.Validator;
 import java.io.File;
 import java.io.IOException;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,27 +33,10 @@ public class YMLSourceProcessor extends BaseSourceProcessor {
 	}
 
 	@Override
-	protected File format(
-			File file, String fileName, String absolutePath, String content)
-		throws Exception {
+	protected String postFormat(
+		String content, List<String> checkCategoryNames,
+		String originalReturnCharacter) {
 
-		Set<String> modifiedContents = new HashSet<>();
-		Set<String> modifiedMessages = new TreeSet<>();
-
-		String newContent = _preProcess(content);
-
-		newContent = format(
-			file, fileName, absolutePath, newContent, content,
-			new ArrayList<>(getSourceChecks()), modifiedContents,
-			modifiedMessages, 0);
-
-		newContent = _postProcess(newContent);
-
-		return processFormattedFile(
-			file, fileName, content, newContent, modifiedMessages);
-	}
-
-	private String _postProcess(String content) {
 		StringBuffer sb = new StringBuffer();
 
 		Matcher matcher = _dashPattern2.matcher(content);
@@ -80,15 +60,24 @@ public class YMLSourceProcessor extends BaseSourceProcessor {
 
 		if (sb.length() > 0) {
 			matcher.appendTail(sb);
-
-			return sb.toString();
 		}
 
-		return content;
+		return super.postFormat(
+			sb.toString(), checkCategoryNames, originalReturnCharacter);
 	}
 
-	private String _preProcess(String content) {
+	@Override
+	protected String preFormat(
+			File file, String fileName, String content,
+			List<String> checkCategoryNames, Set<String> modifiedMessages,
+			String originalReturnCharacter)
+		throws Exception {
+
 		StringBundler sb = new StringBundler();
+
+		content = super.preFormat(
+			file, fileName, content, checkCategoryNames, modifiedMessages,
+			originalReturnCharacter);
 
 		content = content.replaceAll("\\n +\\n", "\n\n");
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/YMLSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/YMLSourceProcessor.java
@@ -59,9 +59,11 @@ public class YMLSourceProcessor extends BaseSourceProcessor {
 
 		if (sb.length() > 0) {
 			matcher.appendTail(sb);
+
+			return super.postFormat(sb.toString(), originalReturnCharacter);
 		}
 
-		return super.postFormat(sb.toString(), originalReturnCharacter);
+		return super.postFormat(content, originalReturnCharacter);
 	}
 
 	@Override

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/YMLSourceProcessor.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/processor/YMLSourceProcessor.java
@@ -34,8 +34,7 @@ public class YMLSourceProcessor extends BaseSourceProcessor {
 
 	@Override
 	protected String postFormat(
-		String content, List<String> checkCategoryNames,
-		String originalReturnCharacter) {
+		String content, String originalReturnCharacter) {
 
 		StringBuffer sb = new StringBuffer();
 
@@ -62,22 +61,19 @@ public class YMLSourceProcessor extends BaseSourceProcessor {
 			matcher.appendTail(sb);
 		}
 
-		return super.postFormat(
-			sb.toString(), checkCategoryNames, originalReturnCharacter);
+		return super.postFormat(sb.toString(), originalReturnCharacter);
 	}
 
 	@Override
 	protected String preFormat(
 			File file, String fileName, String content,
-			List<String> checkCategoryNames, Set<String> modifiedMessages,
-			String originalReturnCharacter)
+			Set<String> modifiedMessages, String originalReturnCharacter)
 		throws Exception {
 
 		StringBundler sb = new StringBundler();
 
 		content = super.preFormat(
-			file, fileName, content, checkCategoryNames, modifiedMessages,
-			originalReturnCharacter);
+			file, fileName, content, modifiedMessages, originalReturnCharacter);
 
 		content = content.replaceAll("\\n +\\n", "\n\n");
 

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -20,6 +20,11 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testAnonymousInnerClass() throws Exception {
+		test("AnonymousInnerClass.testjava");
+	}
+
+	@Test
 	public void testAssertUsage() throws Exception {
 		test(
 			"AssertUsage.testjava",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/AnonymousInnerClass.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/AnonymousInnerClass.testjava
@@ -1,0 +1,117 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
+import com.liferay.adaptive.media.image.processor.AMImageProcessor;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Alan Huang
+ */
+@Component(
+	immediate = true, property = "adaptive.media.key=blogs",
+	service = AMImageOptimizer.class
+)
+public class AnonymousInnerClass {
+
+	public void method(
+		long companyId, String configurationEntryUuid, int total,
+		AtomicInteger atomicCounter) {
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_dlFileEntryLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			new ActionableDynamicQuery.AddCriteriaMethod() {
+
+				@Override
+				public void addCriteria(DynamicQuery dynamicQuery) {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
+
+					dynamicQuery.add(companyIdProperty.eq(companyId));
+
+					Property classNameIdProperty = PropertyFactoryUtil.forName(
+						"classNameId");
+
+					dynamicQuery.add(
+						classNameIdProperty.eq(
+							_classNameLocalService.getClassNameId(
+								BlogsEntry.class.getName())));
+
+					Property mimeTypeProperty = PropertyFactoryUtil.forName(
+						"mimeType");
+
+					dynamicQuery.add(
+						mimeTypeProperty.in(
+							_amImageMimeTypeProvider.getSupportedMimeTypes()));
+				}
+
+			});
+		actionableDynamicQuery.setPerformActionMethod(
+			new ActionableDynamicQuery.PerformActionMethod<DLFileEntry>() {
+
+				@Override
+				public void performAction(DLFileEntry dlFileEntry)
+					throws PortalException {
+
+					FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
+
+					try {
+						_amImageProcessor.process(
+							fileEntry.getFileVersion(), configurationEntryUuid);
+
+						_sendStatusMessage(
+							atomicCounter.incrementAndGet(), total);
+					}
+					catch (PortalException portalException) {
+						_log.error(
+							"Unable to process file entry " +
+								fileEntry.getFileEntryId(),
+							portalException);
+					}
+				}
+
+			});
+
+		try {
+			actionableDynamicQuery.performActions();
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException, portalException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AnonymousInnerClass.class);
+
+	@Reference
+	private AMImageMimeTypeProvider _amImageMimeTypeProvider;
+
+	@Reference
+	private AMImageProcessor _amImageProcessor;
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/AnonymousInnerClass.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/AnonymousInnerClass.testjava
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.adaptive.media.image.mime.type.AMImageMimeTypeProvider;
+import com.liferay.adaptive.media.image.processor.AMImageProcessor;
+import com.liferay.blogs.model.BlogsEntry;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author Alan Huang
+ */
+@Component(
+	immediate = true, property = "adaptive.media.key=blogs",
+	service = AMImageOptimizer.class
+)
+public class AnonymousInnerClass {
+
+	public void method(
+		long companyId, String configurationEntryUuid, int total,
+		AtomicInteger atomicCounter) {
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_dlFileEntryLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property companyIdProperty = PropertyFactoryUtil.forName(
+					"companyId");
+
+				dynamicQuery.add(companyIdProperty.eq(companyId));
+
+				Property classNameIdProperty = PropertyFactoryUtil.forName(
+					"classNameId");
+
+				dynamicQuery.add(
+					classNameIdProperty.eq(
+						_classNameLocalService.getClassNameId(
+							BlogsEntry.class.getName())));
+
+				Property mimeTypeProperty = PropertyFactoryUtil.forName(
+					"mimeType");
+
+				dynamicQuery.add(
+					mimeTypeProperty.in(
+						_amImageMimeTypeProvider.getSupportedMimeTypes()));
+			});
+		actionableDynamicQuery.setPerformActionMethod(
+			(DLFileEntry dlFileEntry) -> {
+				FileEntry fileEntry = new LiferayFileEntry(dlFileEntry);
+
+				try {
+					_amImageProcessor.process(
+						fileEntry.getFileVersion(), configurationEntryUuid);
+
+					_sendStatusMessage(atomicCounter.incrementAndGet(), total);
+				}
+				catch (PortalException portalException) {
+					_log.error(
+						"Unable to process file entry " +
+							fileEntry.getFileEntryId(),
+						portalException);
+				}
+			});
+
+		try {
+			actionableDynamicQuery.performActions();
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AnonymousInnerClass.class);
+
+	@Reference
+	private AMImageMimeTypeProvider _amImageMimeTypeProvider;
+
+	@Reference
+	private AMImageProcessor _amImageProcessor;
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/cache/PortalCacheManagerProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/cache/PortalCacheManagerProvider.java
@@ -48,16 +48,6 @@ public class PortalCacheManagerProvider {
 		<PortalCacheManager<? extends Serializable, ?>,
 		 DynamicPortalCacheManager<? extends Serializable, ?>> _serviceTracker;
 
-	static {
-		_serviceTracker = new ServiceTracker<>(
-			_bundleContext,
-			(Class<PortalCacheManager<? extends Serializable, ?>>)
-				(Class<?>)PortalCacheManager.class,
-			new PortalCacheProviderServiceTrackerCustomizer());
-
-		_serviceTracker.open();
-	}
-
 	private static class PortalCacheProviderServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer
 			<PortalCacheManager<? extends Serializable, ?>,
@@ -103,6 +93,16 @@ public class PortalCacheManagerProvider {
 			dynamicPortalCacheManager.setPortalCacheManager(null);
 		}
 
+	}
+
+	static {
+		_serviceTracker = new ServiceTracker<>(
+			_bundleContext,
+			(Class<PortalCacheManager<? extends Serializable, ?>>)
+				(Class<?>)PortalCacheManager.class,
+			new PortalCacheProviderServiceTrackerCustomizer());
+
+		_serviceTracker.open();
 	}
 
 }


### PR DESCRIPTION
1. Preserve original code style when parsing Java to build JavaTerm for customers since they disabled JavaParser
2. Relace the return character with the original return character of clinet files