### PR TITLE
LPD-67155 Update updateFileVersions for ant-bnd to update source-formatter.properties

### DIFF
--- a/modules/sdk/ant-bnd/build.gradle
+++ b/modules/sdk/ant-bnd/build.gradle
@@ -21,5 +21,6 @@ liferay {
 }
 
 updateFileVersions {
+	match(/com\.liferay:com\.liferay\.ant\.bnd:(\d.+),/, "../../../source-formatter.properties")
 	match(/com\.liferay\.ant\.bnd=com\.liferay:com\.liferay\.ant\.bnd:(\d.+)/, "../../../lib/development/dependencies.properties")
 }


### PR DESCRIPTION
This is an update for [LPD-67155](https://liferay.atlassian.net/browse/LPD-67155).

FYI @anthony-chu @annasuszter @kyle-miho 

To test this change:
1. Navigate to `modules/sdk/ant-bnd` and run `gw updateFileVersions`.
2. Assert that the version of `ant-bnd` in `source-formatter.properties` is updated to the version matching `modules/sdk/ant-bnd/bnd.bnd`.