### PR TITLE
LPD-67479 host the PR checklist shell script in liferay-portal

### DIFF
--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -107,8 +107,6 @@ else
 fi
 
 
-echo "Successfully processed '$input_template'. Modified template saved to '$adapted_template'."
-
 remote=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null | cut -d/ -f1)
 git push --set-upstream "${remote:-origin}" "$(git branch --show-current)"
 prefilled_template="${TEMP_DIR}/g.md"

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -13,6 +13,8 @@ declare -a omitted_sections
 
 declare -a gh_args
 
+gh_args+=("pc")
+
 # Function to generate a simplified, consistent short name from a section title
 get_short_name() {
 	local title="$1"

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -162,5 +162,12 @@ if [ "${#omitted_sections[@]}" -gt 0 ]; then
 	done
 fi
 
-echo gh "${gh_args[@]}" --title "$(head -1 "$prefilled_template")" --body "$(tail -n +3 "$prefilled_template")"
-mv -f "$prefilled_template" /tmp/g.lastpr
+cat "$prefilled_template" > /tmp/g.lastpr
+
+tail -n +3 /tmp/g.lastpr > /tmp/g.bodyfile
+
+gh_args+=(--title "$(head -1 /tmp/g.lastpr)")
+gh_args+=(--body-file /tmp/g.bodyfile)
+gh_args+=(--web)
+
+gh "${gh_args[@]}"

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -15,6 +15,18 @@ declare -a gh_args
 
 gh_args+=("pc")
 
+alias_name="pc"
+
+if ! gh alias list | cut -d':' -f1 | grep -q -E "^${alias_name}$"; then
+	echo "Please set the \"${alias_name}\" gh alias using your team's Github username:"
+	echo ""
+	echo "gh alias set ${alias_name} 'pr create -R liferay-team-name/liferay-portal'"
+
+	exit 1
+fi
+
+gh_args+=("${alias_name}")
+
 # Function to generate a simplified, consistent short name from a section title
 get_short_name() {
 	local title="$1"

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -8,10 +8,9 @@ input_template="$(dirname "$0")/pr_description_template.md"
 adapted_template="${TEMP_DIR}/pr_description_template.md"
 
 # Declare arrays to store sections to omit and omitted sections
-declare -a sections_to_omit
-declare -a omitted_sections
-
 declare -a gh_args
+declare -a omitted_sections
+declare -a sections_to_omit
 
 if ! command -v gh >/dev/null; then
 	echo "Please install the gh command-line tool following these instructions: https://github.com/cli/cli#installation"

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp/}$(basename "$0").XXXXXXXXXXXX")
+trap 'rm -rf ${TEMP_DIR}' EXIT
+
 # Define the input file and output file names
 input_template=~/.pr_description_template.md
-adapted_template=$(mktemp /tmp/pr_description_template.XXXXXXXXXXX.md)
+adapted_template="${TEMP_DIR}/pr_description_template.md"
 
 # Declare arrays to store sections to omit and omitted sections
 declare -a sections_to_omit
@@ -117,7 +120,7 @@ echo "Successfully processed '$input_template'. Modified template saved to '$ada
 
 remote=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null | cut -d/ -f1)
 git push --set-upstream ${remote:-origin} $(git branch --show-current)
-prefilled_template=$(mktemp /tmp/g.XXXXXXXXXXX.md)
+prefilled_template="${TEMP_DIR}/g.md"
 if [[ -f $adapted_template ]]; then
 	lps=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
 	if [[ ! -z $lps ]]; then

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -13,7 +13,11 @@ declare -a omitted_sections
 
 declare -a gh_args
 
-gh_args+=("pc")
+if ! command -v gh >/dev/null; then
+	echo "Please install the gh command-line tool following these instructions: https://github.com/cli/cli#installation"
+
+	exit 1
+fi
 
 alias_name="pc"
 

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -112,7 +112,7 @@ git push --set-upstream "${remote:-origin}" "$(git branch --show-current)"
 prefilled_template="${TEMP_DIR}/g.md"
 if [[ -f $adapted_template ]]; then
 	lpd=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
-	if [[ ! -z $lpd ]]; then
+	if [[ "$lpd" ]]; then
 		url="https://liferay.atlassian.net/browse/"$lpd
 		sed -e "s/{lpd}/$lpd/g" -e "s,{url},$url," <"$adapted_template" >"$prefilled_template"
 	fi

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -131,9 +131,7 @@ if [[ -f $adapted_template ]]; then
 	fi
 fi
 
-vi ${prefilled_template}
-
-#echo ${GH_EDITOR:-${VISUAL:-${EDITOR:-ed}}} ${prefilled_template} >/dev/null
+"${GH_EDITOR:-${VISUAL:-${EDITOR:-ed}}}" "${prefilled_template}"
 
 # Function to extract and clean 2nd-level sections
 extract_sections() {

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -16,8 +16,9 @@ declare -a gh_args
 # Function to generate a simplified, consistent short name from a section title
 get_short_name() {
 	local title="$1"
+	local sanitized_title
 	# Convert to lowercase and replace spaces with hyphens
-	local sanitized_title=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+	sanitized_title=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 	# Remove punctuation and special characters
 	sanitized_title=$(echo "$sanitized_title" | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g')
 
@@ -61,7 +62,7 @@ for arg in "$@"; do
 	elif [ "$arg" == "-h" ] || [ "$arg" == "--help" ]; then
 		usage
 	else
-		gh_args+="${arg}"
+		gh_args+=("${arg}")
 	fi
 done
 
@@ -74,12 +75,12 @@ fi
 
 # Process the markdown file
 omitting=false
->"$adapted_template" # Clear the output file before writing
+true >"$adapted_template" # Clear the output file before writing
 while IFS= read -r line; do
 	# Check if the line is a level 2 heading
 	if [[ "$line" =~ ^"## " ]]; then
 		# Extract the section title and get its short name
-		title_raw=$(echo "$line" | sed 's/^## //')
+		title_raw="${line/#\#\# /}"
 		title_short_name=$(get_short_name "$title_raw")
 
 		# Check if this section should be omitted
@@ -118,14 +119,14 @@ done <"$input_template"
 
 echo "Successfully processed '$input_template'. Modified template saved to '$adapted_template'."
 
-remote=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null | cut -d/ -f1)
-git push --set-upstream ${remote:-origin} $(git branch --show-current)
+remote=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null | cut -d/ -f1)
+git push --set-upstream "${remote:-origin}" "$(git branch --show-current)"
 prefilled_template="${TEMP_DIR}/g.md"
 if [[ -f $adapted_template ]]; then
 	lps=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
 	if [[ ! -z $lps ]]; then
 		url="https://liferay.atlassian.net/browse/"$lps
-		sed -e "s/{lps}/$lps/g" -e "s,{url},$url," <$adapted_template >$prefilled_template
+		sed -e "s/{lps}/$lps/g" -e "s,{url},$url," <"$adapted_template" >"$prefilled_template"
 	fi
 fi
 
@@ -158,5 +159,5 @@ if [ -n "$omitted_sections" ]; then
 	done
 fi
 
-echo gh $gh_args --title "$(head -1 $prefilled_template)" --body "$(tail -n +3 $prefilled_template)"
-mv -f $prefilled_template /tmp/g.lastpr
+echo gh "${gh_args[@]}" --title "$(head -1 "$prefilled_template")" --body "$(tail -n +3 "$prefilled_template")"
+mv -f "$prefilled_template" /tmp/g.lastpr

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -106,16 +106,6 @@ else
 	done <"$input_template"
 fi
 
-# Add the "Omitted Sections" summary at the end
-# if [ ${#omitted_sections[@]} -gt 0 ]; then
-#     echo "" >> "$adapted_template"
-#     echo "---" >> "$adapted_template"
-#     echo "" >> "$adapted_template"
-#     echo "## Omitted Sections" >> "$adapted_template"
-#     for section_title in "${omitted_sections[@]}"; do
-#         echo "  - $section_title" >> "$adapted_template"
-#     done
-# fi
 
 echo "Successfully processed '$input_template'. Modified template saved to '$adapted_template'."
 

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -12,95 +12,95 @@ declare -a gh_args
 
 # Function to generate a simplified, consistent short name from a section title
 get_short_name() {
-    local title="$1"
-    # Convert to lowercase and replace spaces with hyphens
-    local sanitized_title=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
-    # Remove punctuation and special characters
-    sanitized_title=$(echo "$sanitized_title" | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g')
-    
-    # Custom abbreviations for common phrases
-    case "$sanitized_title" in
-        "why-doesnt-this-include-any-test") echo "test" ;;
-        "has-a11y-been-checked") echo "a11y" ;;
-        "do-you-include-custom-css") echo "css" ;;
-        "have-you-introduced-breaking-changes") echo "breaking" ;;
-        "are-you-affecting-other-teams-functionalities") echo "teams" ;;
-        "how-does-this-affect-performance") echo "performance" ;;
-        "have-you-followed-well-established-secure-coding-patterns") echo "secure" ;;
-        *) echo "$sanitized_title" ;; # Default to the full sanitized name
-    esac
+	local title="$1"
+	# Convert to lowercase and replace spaces with hyphens
+	local sanitized_title=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+	# Remove punctuation and special characters
+	sanitized_title=$(echo "$sanitized_title" | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g')
+
+	# Custom abbreviations for common phrases
+	case "$sanitized_title" in
+	"why-doesnt-this-include-any-test") echo "test" ;;
+	"has-a11y-been-checked") echo "a11y" ;;
+	"do-you-include-custom-css") echo "css" ;;
+	"have-you-introduced-breaking-changes") echo "breaking" ;;
+	"are-you-affecting-other-teams-functionalities") echo "teams" ;;
+	"how-does-this-affect-performance") echo "performance" ;;
+	"have-you-followed-well-established-secure-coding-patterns") echo "secure" ;;
+	*) echo "$sanitized_title" ;; # Default to the full sanitized name
+	esac
 }
 
 # Function to display help and usage
 usage() {
-    echo "Usage: $0 [--no-section-1 --no-section-2 ...]"
-    echo "This script create a tailored template for your PR description"
-    echo ""
-    echo "Available sections to omit (use --no-XXXX):"
-    grep -E '^## ' "$input_template" | sed 's/## //' | while read -r line; do
-        short_name=$(get_short_name "$line")
-        echo "  --no-$short_name"
-    done
-    echo ""
-    exit 1
+	echo "Usage: $0 [--no-section-1 --no-section-2 ...]"
+	echo "This script create a tailored template for your PR description"
+	echo ""
+	echo "Available sections to omit (use --no-XXXX):"
+	grep -E '^## ' "$input_template" | sed 's/## //' | while read -r line; do
+		short_name=$(get_short_name "$line")
+		echo "  --no-$short_name"
+	done
+	echo ""
+	exit 1
 }
 
 # Check if the input file is provided and exists
 if [ -z "$input_template" ] || [ ! -f "$input_template" ]; then
-    echo "Error: File '$input_template' not found or not specified."
-    usage
+	echo "Error: File '$input_template' not found or not specified."
+	usage
 fi
 
 # Parse command line arguments to identify sections to omit
 for arg in "$@"; do
-    if [[ "$arg" == "--no-"* ]]; then
-        sections_to_omit+=("${arg#--no-}")
-    elif [ "$arg" == "-h" ] || [ "$arg" == "--help" ]; then
-        usage
-    else
-        gh_args+="${arg}"
-    fi
+	if [[ "$arg" == "--no-"* ]]; then
+		sections_to_omit+=("${arg#--no-}")
+	elif [ "$arg" == "-h" ] || [ "$arg" == "--help" ]; then
+		usage
+	else
+		gh_args+="${arg}"
+	fi
 done
 
 # If no sections are specified for omission, just copy the file
 if [ ${#sections_to_omit[@]} -eq 0 ]; then
-    echo "No sections specified for omission. Creating a copy of the original template."
-    cp "$input_template" "$adapted_template"
+	echo "No sections specified for omission. Creating a copy of the original template."
+	cp "$input_template" "$adapted_template"
 #     exit 0
 fi
 
 # Process the markdown file
 omitting=false
-> "$adapted_template" # Clear the output file before writing
+>"$adapted_template" # Clear the output file before writing
 while IFS= read -r line; do
-    # Check if the line is a level 2 heading
-    if [[ "$line" =~ ^"## " ]]; then
-        # Extract the section title and get its short name
-        title_raw=$(echo "$line" | sed 's/^## //')
-        title_short_name=$(get_short_name "$title_raw")
+	# Check if the line is a level 2 heading
+	if [[ "$line" =~ ^"## " ]]; then
+		# Extract the section title and get its short name
+		title_raw=$(echo "$line" | sed 's/^## //')
+		title_short_name=$(get_short_name "$title_raw")
 
-        # Check if this section should be omitted
-        should_omit=false
-        for omit_name in "${sections_to_omit[@]}"; do
-            if [ "$title_short_name" == "$omit_name" ]; then
-                should_omit=true
-                omitted_sections+=("$title_raw")
-                break
-            fi
-        done
+		# Check if this section should be omitted
+		should_omit=false
+		for omit_name in "${sections_to_omit[@]}"; do
+			if [ "$title_short_name" == "$omit_name" ]; then
+				should_omit=true
+				omitted_sections+=("$title_raw")
+				break
+			fi
+		done
 
-        if [ "$should_omit" == true ]; then
-            omitting=true
-            continue
-        else
-            omitting=false
-            echo "$line" >> "$adapted_template"
-        fi
-    elif [ "$omitting" == false ]; then
-        # If not a header and we are not currently omitting, write the line
-        echo "$line" >> "$adapted_template"
-    fi
-done < "$input_template"
+		if [ "$should_omit" == true ]; then
+			omitting=true
+			continue
+		else
+			omitting=false
+			echo "$line" >>"$adapted_template"
+		fi
+	elif [ "$omitting" == false ]; then
+		# If not a header and we are not currently omitting, write the line
+		echo "$line" >>"$adapted_template"
+	fi
+done <"$input_template"
 
 # Add the "Omitted Sections" summary at the end
 # if [ ${#omitted_sections[@]} -gt 0 ]; then
@@ -118,14 +118,12 @@ echo "Successfully processed '$input_template'. Modified template saved to '$ada
 remote=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null | cut -d/ -f1)
 git push --set-upstream ${remote:-origin} $(git branch --show-current)
 prefilled_template=$(mktemp /tmp/g.XXXXXXXXXXX.md)
-if [[ -f $adapted_template ]]
-then
-    lps=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
-    if [[ ! -z $lps ]]
-    then
-        url="https://liferay.atlassian.net/browse/"$lps
-        sed -e "s/{lps}/$lps/g" -e "s,{url},$url," <$adapted_template >$prefilled_template
-    fi
+if [[ -f $adapted_template ]]; then
+	lps=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
+	if [[ ! -z $lps ]]; then
+		url="https://liferay.atlassian.net/browse/"$lps
+		sed -e "s/{lps}/$lps/g" -e "s,{url},$url," <$adapted_template >$prefilled_template
+	fi
 fi
 
 vi ${prefilled_template}
@@ -134,9 +132,9 @@ vi ${prefilled_template}
 
 # Function to extract and clean 2nd-level sections
 extract_sections() {
-    local file=$1
-    # Use grep to find lines starting with '## ', then sed to remove the '## ' prefix and trim whitespace
-    grep "^## " "$file" | sed 's/^## //g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+	local file=$1
+	# Use grep to find lines starting with '## ', then sed to remove the '## ' prefix and trim whitespace
+	grep "^## " "$file" | sed 's/^## //g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
 # Extract sections from both files and sort them
@@ -147,16 +145,15 @@ filled_sections=$(extract_sections "${prefilled_template}" | sort)
 omitted_sections=$(comm -23 <(echo "$template_sections") <(echo "$filled_sections"))
 
 # Append the missing sections to the filled file if any were found
-if [ -n "$omitted_sections" ]; then    
-    # Append the sections to the filled file with a 2nd-level heading and a placeholder for content
-    echo -e "\n\n" >> "${prefilled_template}"
-    echo -e "## Omitted Sections" >> "${prefilled_template}"
-    
-    echo "$omitted_sections" | while read -r line; do
-        echo "  - $line" >> "${prefilled_template}"
-    done
+if [ -n "$omitted_sections" ]; then
+	# Append the sections to the filled file with a 2nd-level heading and a placeholder for content
+	echo -e "\n\n" >>"${prefilled_template}"
+	echo -e "## Omitted Sections" >>"${prefilled_template}"
+
+	echo "$omitted_sections" | while read -r line; do
+		echo "  - $line" >>"${prefilled_template}"
+	done
 fi
 
 echo gh $gh_args --title "$(head -1 $prefilled_template)" --body "$(tail -n +3 $prefilled_template)"
 mv -f $prefilled_template /tmp/g.lastpr
-

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -72,40 +72,39 @@ done
 if [ ${#sections_to_omit[@]} -eq 0 ]; then
 	echo "No sections specified for omission. Creating a copy of the original template."
 	cp "$input_template" "$adapted_template"
-#     exit 0
-fi
+else
+	# Process the markdown file
+	omitting=false
+	true >"$adapted_template" # Clear the output file before writing
+	while IFS= read -r line; do
+		# Check if the line is a level 2 heading
+		if [[ "$line" =~ ^"## " ]]; then
+			# Extract the section title and get its short name
+			title_raw="${line/#\#\# /}"
+			title_short_name=$(get_short_name "$title_raw")
 
-# Process the markdown file
-omitting=false
-true >"$adapted_template" # Clear the output file before writing
-while IFS= read -r line; do
-	# Check if the line is a level 2 heading
-	if [[ "$line" =~ ^"## " ]]; then
-		# Extract the section title and get its short name
-		title_raw="${line/#\#\# /}"
-		title_short_name=$(get_short_name "$title_raw")
+			# Check if this section should be omitted
+			should_omit=false
+			for omit_name in "${sections_to_omit[@]}"; do
+				if [ "$title_short_name" == "$omit_name" ]; then
+					should_omit=true
+					break
+				fi
+			done
 
-		# Check if this section should be omitted
-		should_omit=false
-		for omit_name in "${sections_to_omit[@]}"; do
-			if [ "$title_short_name" == "$omit_name" ]; then
-				should_omit=true
-				break
+			if [ "$should_omit" == true ]; then
+				omitting=true
+				continue
+			else
+				omitting=false
+				echo "$line" >>"$adapted_template"
 			fi
-		done
-
-		if [ "$should_omit" == true ]; then
-			omitting=true
-			continue
-		else
-			omitting=false
+		elif [ "$omitting" == false ]; then
+			# If not a header and we are not currently omitting, write the line
 			echo "$line" >>"$adapted_template"
 		fi
-	elif [ "$omitting" == false ]; then
-		# If not a header and we are not currently omitting, write the line
-		echo "$line" >>"$adapted_template"
-	fi
-done <"$input_template"
+	done <"$input_template"
+fi
 
 # Add the "Omitted Sections" summary at the end
 # if [ ${#omitted_sections[@]} -gt 0 ]; then

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -122,10 +122,10 @@ remote=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null | cu
 git push --set-upstream "${remote:-origin}" "$(git branch --show-current)"
 prefilled_template="${TEMP_DIR}/g.md"
 if [[ -f $adapted_template ]]; then
-	lps=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
-	if [[ ! -z $lps ]]; then
-		url="https://liferay.atlassian.net/browse/"$lps
-		sed -e "s/{lps}/$lps/g" -e "s,{url},$url," <"$adapted_template" >"$prefilled_template"
+	lpd=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
+	if [[ ! -z $lpd ]]; then
+		url="https://liferay.atlassian.net/browse/"$lpd
+		sed -e "s/{lpd}/$lpd/g" -e "s,{url},$url," <"$adapted_template" >"$prefilled_template"
 	fi
 fi
 

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -88,7 +88,6 @@ while IFS= read -r line; do
 		for omit_name in "${sections_to_omit[@]}"; do
 			if [ "$title_short_name" == "$omit_name" ]; then
 				should_omit=true
-				omitted_sections+=("$title_raw")
 				break
 			fi
 		done
@@ -146,15 +145,17 @@ template_sections=$(extract_sections "$input_template" | sort)
 filled_sections=$(extract_sections "${prefilled_template}" | sort)
 
 # Use `comm` to find lines unique to the first file (template_sections)
-omitted_sections=$(comm -23 <(echo "$template_sections") <(echo "$filled_sections"))
+while read -r line; do
+	omitted_sections+=("${line}")
+done < <(comm -23 <(echo "$template_sections") <(echo "$filled_sections"))
 
 # Append the missing sections to the filled file if any were found
-if [ -n "$omitted_sections" ]; then
+if [ "${#omitted_sections[@]}" -gt 0 ]; then
 	# Append the sections to the filled file with a 2nd-level heading and a placeholder for content
 	echo -e "\n\n" >>"${prefilled_template}"
 	echo -e "## Omitted Sections" >>"${prefilled_template}"
 
-	echo "$omitted_sections" | while read -r line; do
+	for line in "${omitted_sections[@]}"; do
 		echo "  - $line" >>"${prefilled_template}"
 	done
 fi

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -4,7 +4,7 @@ TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp/}$(basename "$0").XXXXXXXXXXXX")
 trap 'rm -rf ${TEMP_DIR}' EXIT
 
 # Define the input file and output file names
-input_template=~/.pr_description_template.md
+input_template="$(dirname "$0")/pr_description_template.md"
 adapted_template="${TEMP_DIR}/pr_description_template.md"
 
 # Declare arrays to store sections to omit and omitted sections

--- a/tools/open_editor_with_pr_description_template.sh
+++ b/tools/open_editor_with_pr_description_template.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# Define the input file and output file names
+input_template=~/.pr_description_template.md
+adapted_template=$(mktemp /tmp/pr_description_template.XXXXXXXXXXX.md)
+
+# Declare arrays to store sections to omit and omitted sections
+declare -a sections_to_omit
+declare -a omitted_sections
+
+declare -a gh_args
+
+# Function to generate a simplified, consistent short name from a section title
+get_short_name() {
+    local title="$1"
+    # Convert to lowercase and replace spaces with hyphens
+    local sanitized_title=$(echo "$title" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+    # Remove punctuation and special characters
+    sanitized_title=$(echo "$sanitized_title" | sed 's/[^a-z0-9-]//g' | sed 's/--/-/g')
+    
+    # Custom abbreviations for common phrases
+    case "$sanitized_title" in
+        "why-doesnt-this-include-any-test") echo "test" ;;
+        "has-a11y-been-checked") echo "a11y" ;;
+        "do-you-include-custom-css") echo "css" ;;
+        "have-you-introduced-breaking-changes") echo "breaking" ;;
+        "are-you-affecting-other-teams-functionalities") echo "teams" ;;
+        "how-does-this-affect-performance") echo "performance" ;;
+        "have-you-followed-well-established-secure-coding-patterns") echo "secure" ;;
+        *) echo "$sanitized_title" ;; # Default to the full sanitized name
+    esac
+}
+
+# Function to display help and usage
+usage() {
+    echo "Usage: $0 [--no-section-1 --no-section-2 ...]"
+    echo "This script create a tailored template for your PR description"
+    echo ""
+    echo "Available sections to omit (use --no-XXXX):"
+    grep -E '^## ' "$input_template" | sed 's/## //' | while read -r line; do
+        short_name=$(get_short_name "$line")
+        echo "  --no-$short_name"
+    done
+    echo ""
+    exit 1
+}
+
+# Check if the input file is provided and exists
+if [ -z "$input_template" ] || [ ! -f "$input_template" ]; then
+    echo "Error: File '$input_template' not found or not specified."
+    usage
+fi
+
+# Parse command line arguments to identify sections to omit
+for arg in "$@"; do
+    if [[ "$arg" == "--no-"* ]]; then
+        sections_to_omit+=("${arg#--no-}")
+    elif [ "$arg" == "-h" ] || [ "$arg" == "--help" ]; then
+        usage
+    else
+        gh_args+="${arg}"
+    fi
+done
+
+# If no sections are specified for omission, just copy the file
+if [ ${#sections_to_omit[@]} -eq 0 ]; then
+    echo "No sections specified for omission. Creating a copy of the original template."
+    cp "$input_template" "$adapted_template"
+#     exit 0
+fi
+
+# Process the markdown file
+omitting=false
+> "$adapted_template" # Clear the output file before writing
+while IFS= read -r line; do
+    # Check if the line is a level 2 heading
+    if [[ "$line" =~ ^"## " ]]; then
+        # Extract the section title and get its short name
+        title_raw=$(echo "$line" | sed 's/^## //')
+        title_short_name=$(get_short_name "$title_raw")
+
+        # Check if this section should be omitted
+        should_omit=false
+        for omit_name in "${sections_to_omit[@]}"; do
+            if [ "$title_short_name" == "$omit_name" ]; then
+                should_omit=true
+                omitted_sections+=("$title_raw")
+                break
+            fi
+        done
+
+        if [ "$should_omit" == true ]; then
+            omitting=true
+            continue
+        else
+            omitting=false
+            echo "$line" >> "$adapted_template"
+        fi
+    elif [ "$omitting" == false ]; then
+        # If not a header and we are not currently omitting, write the line
+        echo "$line" >> "$adapted_template"
+    fi
+done < "$input_template"
+
+# Add the "Omitted Sections" summary at the end
+# if [ ${#omitted_sections[@]} -gt 0 ]; then
+#     echo "" >> "$adapted_template"
+#     echo "---" >> "$adapted_template"
+#     echo "" >> "$adapted_template"
+#     echo "## Omitted Sections" >> "$adapted_template"
+#     for section_title in "${omitted_sections[@]}"; do
+#         echo "  - $section_title" >> "$adapted_template"
+#     done
+# fi
+
+echo "Successfully processed '$input_template'. Modified template saved to '$adapted_template'."
+
+remote=$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null | cut -d/ -f1)
+git push --set-upstream ${remote:-origin} $(git branch --show-current)
+prefilled_template=$(mktemp /tmp/g.XXXXXXXXXXX.md)
+if [[ -f $adapted_template ]]
+then
+    lps=$(git show --pretty='format:%s' --no-patch | cut -d' ' -f1)
+    if [[ ! -z $lps ]]
+    then
+        url="https://liferay.atlassian.net/browse/"$lps
+        sed -e "s/{lps}/$lps/g" -e "s,{url},$url," <$adapted_template >$prefilled_template
+    fi
+fi
+
+vi ${prefilled_template}
+
+#echo ${GH_EDITOR:-${VISUAL:-${EDITOR:-ed}}} ${prefilled_template} >/dev/null
+
+# Function to extract and clean 2nd-level sections
+extract_sections() {
+    local file=$1
+    # Use grep to find lines starting with '## ', then sed to remove the '## ' prefix and trim whitespace
+    grep "^## " "$file" | sed 's/^## //g' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+# Extract sections from both files and sort them
+template_sections=$(extract_sections "$input_template" | sort)
+filled_sections=$(extract_sections "${prefilled_template}" | sort)
+
+# Use `comm` to find lines unique to the first file (template_sections)
+omitted_sections=$(comm -23 <(echo "$template_sections") <(echo "$filled_sections"))
+
+# Append the missing sections to the filled file if any were found
+if [ -n "$omitted_sections" ]; then    
+    # Append the sections to the filled file with a 2nd-level heading and a placeholder for content
+    echo -e "\n\n" >> "${prefilled_template}"
+    echo -e "## Omitted Sections" >> "${prefilled_template}"
+    
+    echo "$omitted_sections" | while read -r line; do
+        echo "  - $line" >> "${prefilled_template}"
+    done
+fi
+
+echo gh $gh_args --title "$(head -1 $prefilled_template)" --body "$(tail -n +3 $prefilled_template)"
+mv -f $prefilled_template /tmp/g.lastpr
+

--- a/tools/pr_description_template.md
+++ b/tools/pr_description_template.md
@@ -1,0 +1,77 @@
+{lpd} This is the pull request title
+
+# What is this trying to solve?
+
+{url}
+
+Explain *what* you're trying to do, without talking about *how* you're doing it.
+Here, brevity is a virtue, don't get into too much detail. An overview should be
+more than enough.
+
+# How am I fixing it?
+
+Don't repeat what the code already says, try to give a bird's eye perspective so
+that the code is easier to understand.
+
+# How can you verify that it works?
+
+If the PR includes automated tests, simply saying "Run the included automated
+tests." is enough. Please, add extra information that might be needed to 
+understand the testing strategy.
+
+If the PR doesn't include tests, and the ticket includes reproduction steps:
+"Follow the steps described in {url}."
+
+Otherwise, define a procedure to test the changes using a numbered list. E.g:
+1. Go to "Foo".
+2. Click on "Bar".
+3. Go back to step #1.
+
+# High level requirements rationale
+
+## Why doesn't this include any test?
+
+If the PR contains automated tests, omit this section.
+
+Otherwise, you need to give a rationale of why.
+
+## Has a11y been checked?
+
+If the PR is not relate at all with the UI, omit this section.
+
+Otherwise, you need to give a rationale of how.
+
+## Do you include custom CSS?
+
+If the PR does not contain custom CSS, omit this section.
+
+Otherwise, you need to give a rationale of why.
+
+## Have you introduced breaking changes?
+
+If the PR does not introduce breaking changes, omit this section.
+
+Otherwise, you need to explain the rationale of why. You can 
+refer to the particular commit message where this is explained.
+
+## Are you affecting other teams functionalities?
+
+If the PR does not affect other team functionalities, omit this section.
+
+Otherwise, you need to give a rationale of why, and a description of the 
+mitigation plan agreed with other teams.
+
+## How does this affect performance?
+
+If you are confident that this PR does not affect performance, omit this section.
+
+If performance could be affected (postively or negatively), please explain them.
+Make references to how the differences were measured.
+
+## Have you followed well established secure coding patterns?
+
+If you have escaped user input, avoid path traversal, controlled user access, ... 
+(see https://owasp.org/www-project-top-ten/), you can omit this section.
+
+If there is any particular aspect that the reviewer should take care particularly, 
+please, explain it so it can be properly considered.


### PR DESCRIPTION
# What is this trying to solve?

https://liferay.atlassian.net/browse/LPD-67479

The new PR initiative uses a shell script and template to standardize PR format to ensure that certain items are always considered. This shell script and template need to be hosted somewhere.

# How am I fixing it?

We will store the script and template in the `liferay-portal/tools` directory.

# How can you verify that it works?

Follow the instructions at https://liferay.atlassian.net/wiki/spaces/~12872496/pages/4008083478/Sub-Play+PR+management+process+for+PR+senders.




## Omitted Sections
  - Are you affecting other teams functionalities?
  - Do you include custom CSS?
  - Has a11y been checked?
  - Have you followed well established secure coding patterns?
  - Have you introduced breaking changes?
  - How does this affect performance?
  - Why doesn't this include any test?
