### PR TITLE
LPD-85801 SF rule to force using getLong("count")

### DIFF
--- a/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/upgrade/v2_11_1/AccountRoleResourceUpgradeProcess.java
+++ b/modules/apps/account/account-service/src/main/java/com/liferay/account/internal/upgrade/v2_11_1/AccountRoleResourceUpgradeProcess.java
@@ -37,7 +37,7 @@ public class AccountRoleResourceUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				if (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_0/CountryUpgradeProcess.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/upgrade/v1_0_0/CountryUpgradeProcess.java
@@ -454,7 +454,7 @@ public class CountryUpgradeProcess extends UpgradeProcess {
 
 				try (ResultSet resultSet = preparedStatement.executeQuery()) {
 					while (resultSet.next()) {
-						if (resultSet.getInt("count") > 0) {
+						if (resultSet.getLong("count") > 0) {
 							return true;
 						}
 					}

--- a/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_0/test/CountryUpgradeProcessTest.java
+++ b/modules/apps/address/address-test/src/testIntegration/java/com/liferay/address/internal/upgrade/v1_0_0/test/CountryUpgradeProcessTest.java
@@ -63,10 +63,10 @@ public class CountryUpgradeProcessTest {
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
-			int countryCount = _getCount("Country");
-			int countryLocalizationCount = _getCount("CountryLocalization");
-			int regionCount = _getCount("Region");
-			int regionLocalizationCount = _getCount("RegionLocalization");
+			long countryCount = _getCount("Country");
+			long countryLocalizationCount = _getCount("CountryLocalization");
+			long regionCount = _getCount("Region");
+			long regionLocalizationCount = _getCount("RegionLocalization");
 
 			_delete("Country");
 			_delete("CountryLocalization");
@@ -127,7 +127,7 @@ public class CountryUpgradeProcessTest {
 		}
 	}
 
-	private int _getCount(String tableName) throws Exception {
+	private long _getCount(String tableName) throws Exception {
 		try (Connection connection = DataAccess.getConnection();
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -139,7 +139,7 @@ public class CountryUpgradeProcessTest {
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				resultSet.next();
 
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 	}

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/background/task/CTServicePublisher.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/background/task/CTServicePublisher.java
@@ -121,7 +121,7 @@ public class CTServicePublisher<T extends CTModel<T>> {
 		CTRowUtil.copyCTRows(ctPersistence, connection, sb.toString());
 	}
 
-	private int _getPredeletedRowCount(
+	private long _getPredeletedRowCount(
 			Connection connection, String tableName, String primaryKeyName)
 		throws Exception {
 
@@ -141,7 +141,7 @@ public class CTServicePublisher<T extends CTModel<T>> {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				if (resultSet.next()) {
-					return resultSet.getInt("count");
+					return resultSet.getLong("count");
 				}
 			}
 		}
@@ -188,7 +188,7 @@ public class CTServicePublisher<T extends CTModel<T>> {
 		}
 
 		if (_deletionCTEntries != null) {
-			int predeletedRowCount = _getPredeletedRowCount(
+			long predeletedRowCount = _getPredeletedRowCount(
 				connection, tableName, primaryKeyName);
 
 			if (predeletedRowCount != _deletionCTEntries.size()) {

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/score/CTScoreCalculator.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/score/CTScoreCalculator.java
@@ -93,7 +93,7 @@ public class CTScoreCalculator {
 		_portalCache.removeAll();
 	}
 
-	private long _countTable(long modelClassNameId) {
+	private int _countTable(long modelClassNameId) {
 		CTService<?> ctService = _ctServiceRegistry.getCTService(
 			modelClassNameId);
 
@@ -130,7 +130,7 @@ public class CTScoreCalculator {
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
 					if (resultSet.next()) {
-						return resultSet.getLong("count");
+						return (int)resultSet.getLong("count");
 					}
 
 					return 0;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/score/CTScoreCalculator.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/internal/score/CTScoreCalculator.java
@@ -93,7 +93,7 @@ public class CTScoreCalculator {
 		_portalCache.removeAll();
 	}
 
-	private int _countTable(long modelClassNameId) {
+	private long _countTable(long modelClassNameId) {
 		CTService<?> ctService = _ctServiceRegistry.getCTService(
 			modelClassNameId);
 
@@ -130,7 +130,7 @@ public class CTScoreCalculator {
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
 					if (resultSet.next()) {
-						return resultSet.getInt("count");
+						return resultSet.getLong("count");
 					}
 
 					return 0;

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -872,7 +872,7 @@ public class CTCollectionLocalServiceImpl
 				preparedStatement.setLong(1, ctCollectionId);
 
 				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					if (resultSet.next() && (resultSet.getInt("count") > 0)) {
+					if (resultSet.next() && (resultSet.getLong("count") > 0)) {
 						return true;
 					}
 				}

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/LayoutCTTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/internal/test/LayoutCTTest.java
@@ -1239,7 +1239,7 @@ public class LayoutCTTest {
 				try (ResultSet resultSet = preparedStatement.executeQuery()) {
 					Assert.assertTrue(resultSet.next());
 
-					Assert.assertEquals(2, resultSet.getInt("count"));
+					Assert.assertEquals(2, resultSet.getLong("count"));
 
 					Assert.assertFalse(resultSet.next());
 				}

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTCollectionServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTCollectionServiceTest.java
@@ -232,7 +232,7 @@ public class CTCollectionServiceTest {
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				Assert.assertTrue(resultSet.next());
 
-				Assert.assertEquals(0, resultSet.getInt("count"));
+				Assert.assertEquals(0, resultSet.getLong("count"));
 			}
 		}
 

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v2_1_0/ResourcePermissionsUpgradeProcess.java
@@ -40,7 +40,7 @@ public class ResourcePermissionsUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v5_22_0/test/CPSpecificationOptionUpgradeProcessTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v5_22_0/test/CPSpecificationOptionUpgradeProcessTest.java
@@ -96,7 +96,7 @@ public class CPSpecificationOptionUpgradeProcessTest {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					Assert.assertEquals(1, resultSet.getInt("count"));
+					Assert.assertEquals(1, resultSet.getLong("count"));
 				}
 			}
 		}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v7_1_2/CommerceAccountRoleUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v7_1_2/CommerceAccountRoleUpgradeProcess.java
@@ -203,7 +203,7 @@ public class CommerceAccountRoleUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/upgrade/v14_0_0/test/ObjectDefinitionUpgradeProcessTest.java
+++ b/modules/apps/commerce/commerce-test/src/testIntegration/java/com/liferay/commerce/internal/upgrade/v14_0_0/test/ObjectDefinitionUpgradeProcessTest.java
@@ -364,7 +364,7 @@ public class ObjectDefinitionUpgradeProcessTest {
 
 			Assert.assertNotNull(resultSet.next());
 
-			Assert.assertEquals(1L, resultSet.getInt("count"));
+			Assert.assertEquals(1L, resultSet.getLong("count"));
 		}
 	}
 

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -161,7 +161,7 @@ public class CompanyLocalServiceDBPartitionTest
 	@Test
 	public void testAddCompany() throws Exception {
 		int dbPartitionsCount = _getDBPartitionsCount();
-		int rulesCount = _getRulesCount(defaultPartitionName);
+		long rulesCount = _getRulesCount(defaultPartitionName);
 
 		_company1 = CompanyTestUtil.addCompany();
 
@@ -489,7 +489,7 @@ public class CompanyLocalServiceDBPartitionTest
 	@FeatureFlag("LPD-11342")
 	@Test
 	public void testCopyDBPartitionCompany() throws Exception {
-		int rulesCount = _getRulesCount(defaultPartitionName);
+		long rulesCount = _getRulesCount(defaultPartitionName);
 
 		Configuration configuration =
 			CompanyLocalServiceTestUtil.createFactoryConfiguration(
@@ -1133,7 +1133,7 @@ public class CompanyLocalServiceDBPartitionTest
 		throw new SQLException("At least one database partition is required");
 	}
 
-	private int _getRulesCount(String partitionName) throws Exception {
+	private long _getRulesCount(String partitionName) throws Exception {
 		if (db.getDBType() != DBType.POSTGRESQL) {
 			return 0;
 		}
@@ -1153,7 +1153,7 @@ public class CompanyLocalServiceDBPartitionTest
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				resultSet.next();
 
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 	}

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
@@ -96,7 +96,7 @@ public class ResourcePermissionPostupgradeDataCleanupProcess
 						name);
 
 					DataCleanupLoggingUtil.logDelete(
-						_log, resultSet.getInt("count"),
+						_log, resultSet.getLong("count"),
 						_dbInspector.normalizeName("ResourcePermission"),
 						StringBundler.concat("\"", name, "\" was not found"));
 				}

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/upgrade/test/DLFileEntryDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/upgrade/test/DLFileEntryDataCleanupPreupgradeProcessTest.java
@@ -142,7 +142,7 @@ public class DLFileEntryDataCleanupPreupgradeProcessTest
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				Assert.assertTrue(resultSet.next());
 
-				Assert.assertEquals(0, resultSet.getInt("count"));
+				Assert.assertEquals(0, resultSet.getLong("count"));
 			}
 		}
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldAttributeUpgradeProcess.java
@@ -47,7 +47,7 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_5_1/DDMFieldUpgradeProcess.java
@@ -46,7 +46,7 @@ public class DDMFieldUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/internal/upgrade/v3_4_1/test/LayoutFriendlyURLEntryUpgradeProcessTest.java
@@ -208,11 +208,11 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 
 		_deleteFriendlyURLEntries(draftLayout2, layout2);
 
-		int expectedFriendlyURLEntriesCount =
+		long expectedFriendlyURLEntriesCount =
 			_getRowsCount("FriendlyURLEntry") + 2;
-		int expectedFriendlyURLEntryMappingsCount =
+		long expectedFriendlyURLEntryMappingsCount =
 			_getRowsCount("FriendlyURLEntryMapping") + 2;
-		int expectedFriendlyURLEntryLocalizationsCount =
+		long expectedFriendlyURLEntryLocalizationsCount =
 			_getRowsCount("FriendlyURLEntryLocalization") + 2;
 
 		_assertUpgrade(draftLayout1, draftLayout2, layout1, layout2);
@@ -465,7 +465,7 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 		return friendlyURLEntry;
 	}
 
-	private int _getRowsCount(String tableName) throws Exception {
+	private long _getRowsCount(String tableName) throws Exception {
 		try (Connection connection = DataAccess.getConnection();
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -474,7 +474,7 @@ public class LayoutFriendlyURLEntryUpgradeProcessTest {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next()) {
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_3/JournalArticleTypeUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_3/JournalArticleTypeUpgradeProcess.java
@@ -139,7 +139,7 @@ public class JournalArticleTypeUpgradeProcess extends UpgradeProcess {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
-				if (resultSet.getInt("count") > 0) {
+				if (resultSet.getLong("count") > 0) {
 					return true;
 				}
 			}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/ResourceActionUpgradeProcess.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/ResourceActionUpgradeProcess.java
@@ -35,7 +35,7 @@ public class ResourceActionUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/ResourcePermissionUpgradeProcess.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_1_0/ResourcePermissionUpgradeProcess.java
@@ -37,7 +37,7 @@ public class ResourcePermissionUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_3_3/KBFolderUpgradeProcess.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_3_3/KBFolderUpgradeProcess.java
@@ -50,7 +50,7 @@ public class KBFolderUpgradeProcess extends UpgradeProcess {
 			preparedStatement.setString(1, urlTitle + "%");
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (!resultSet.next() || (resultSet.getInt("count") == 0)) {
+				if (!resultSet.next() || (resultSet.getLong("count") == 0)) {
 					return urlTitle;
 				}
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_3_4/ResourceActionUpgradeProcess.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/upgrade/v1_3_4/ResourceActionUpgradeProcess.java
@@ -41,7 +41,7 @@ public class ResourceActionUpgradeProcess extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				if (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_1/LayoutPageTemplateEntryUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_1/LayoutPageTemplateEntryUpgradeProcess.java
@@ -80,7 +80,7 @@ public class LayoutPageTemplateEntryUpgradeProcess extends UpgradeProcess {
 							countPreparedStatement.executeQuery();
 
 						if (countResultSet.next() &&
-							(countResultSet.getInt("count") > 0)) {
+							(countResultSet.getLong("count") > 0)) {
 
 							newName = name + i;
 						}

--- a/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/upgrade/v3_4_0/NotificationRecipientUpgradeProcess.java
+++ b/modules/apps/notification/notification-service/src/main/java/com/liferay/notification/internal/upgrade/v3_4_0/NotificationRecipientUpgradeProcess.java
@@ -32,10 +32,10 @@ public class NotificationRecipientUpgradeProcess extends UpgradeProcess {
 				"select count(*) as count from NotificationRecipientSetting");
 			ResultSet resultSet2 = preparedStatement2.executeQuery()) {
 
-			if (resultSet1.next() && (resultSet1.getInt("count") > 0)) {
+			if (resultSet1.next() && (resultSet1.getLong("count") > 0)) {
 				return;
 			}
-			else if (resultSet2.next() && (resultSet2.getInt("count") == 0)) {
+			else if (resultSet2.next() && (resultSet2.getLong("count") == 0)) {
 				return;
 			}
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -595,7 +595,7 @@ public class ObjectEntryLocalServiceImpl
 			DynamicObjectDefinitionTableUtil.getDynamicObjectDefinitionTable(
 				true, objectDefinition, _objectFieldLocalService);
 
-		int count = _count(dynamicObjectDefinitionTable, primaryKey);
+		long count = _count(dynamicObjectDefinitionTable, primaryKey);
 
 		String defaultLanguageId = _language.getLanguageId(
 			_portal.getSiteDefaultLocale(
@@ -1874,7 +1874,7 @@ public class ObjectEntryLocalServiceImpl
 			DynamicObjectDefinitionTableUtil.getDynamicObjectDefinitionTable(
 				true, objectDefinition, _objectFieldLocalService);
 
-		int count = _count(dynamicObjectDefinitionTable, primaryKey);
+		long count = _count(dynamicObjectDefinitionTable, primaryKey);
 
 		String defaultLanguageId = _language.getLanguageId(
 			_portal.getSiteDefaultLocale(
@@ -3265,7 +3265,7 @@ public class ObjectEntryLocalServiceImpl
 		}
 	}
 
-	private int _count(
+	private long _count(
 			DynamicObjectDefinitionTable dynamicObjectDefinitionTable,
 			long primaryKey)
 		throws PortalException {
@@ -3291,7 +3291,7 @@ public class ObjectEntryLocalServiceImpl
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				resultSet.next();
 
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 		catch (SQLException sqlException) {
@@ -7326,7 +7326,7 @@ public class ObjectEntryLocalServiceImpl
 			return;
 		}
 
-		int count = 0;
+		long count = 0;
 
 		Connection connection = _currentConnection.getConnection(
 			objectEntryPersistence.getDataSource());
@@ -7342,7 +7342,7 @@ public class ObjectEntryLocalServiceImpl
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				resultSet.next();
 
-				count = resultSet.getInt("count");
+				count = resultSet.getLong("count");
 			}
 		}
 		catch (SQLException sqlException) {
@@ -7366,7 +7366,7 @@ public class ObjectEntryLocalServiceImpl
 			return;
 		}
 
-		int count = 0;
+		long count = 0;
 
 		Connection connection = _currentConnection.getConnection(
 			objectEntryPersistence.getDataSource());
@@ -7384,7 +7384,7 @@ public class ObjectEntryLocalServiceImpl
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				resultSet.next();
 
-				count = resultSet.getInt("count");
+				count = resultSet.getLong("count");
 			}
 		}
 		catch (SQLException sqlException) {

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -7937,7 +7937,7 @@ public class ObjectEntryLocalServiceTest {
 		return false;
 	}
 
-	private int _count() throws Exception {
+	private long _count() throws Exception {
 		try (Connection connection = DataAccess.getConnection();
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -7948,7 +7948,7 @@ public class ObjectEntryLocalServiceTest {
 
 			resultSet.next();
 
-			return resultSet.getInt("count");
+			return resultSet.getLong("count");
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/upgrade/v3_0_1/SAPEntryUpgradeProcess.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/upgrade/v3_0_1/SAPEntryUpgradeProcess.java
@@ -49,7 +49,7 @@ public class SAPEntryUpgradeProcess extends UpgradeProcess {
 
 						resultSet.next();
 
-						if (resultSet.getInt("count") != 0) {
+						if (resultSet.getLong("count") != 0) {
 							return;
 						}
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -712,7 +712,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 				resultSet.next();
 
 				Assert.assertEquals(
-					_PROCESS_CONCURRENTLY_COUNT, resultSet.getInt("count"));
+					_PROCESS_CONCURRENTLY_COUNT, resultSet.getLong("count"));
 			}
 		}
 	}

--- a/modules/apps/portal/portal-db-index-test/src/testIntegration/java/com/liferay/portal/db/index/test/IndexUpdaterUtilTest.java
+++ b/modules/apps/portal/portal-db-index-test/src/testIntegration/java/com/liferay/portal/db/index/test/IndexUpdaterUtilTest.java
@@ -244,7 +244,7 @@ public class IndexUpdaterUtilTest {
 				try (ResultSet resultSet = preparedStatement.executeQuery()) {
 					Assert.assertTrue(resultSet.next());
 
-					Assert.assertEquals(1, resultSet.getInt("count"));
+					Assert.assertEquals(1, resultSet.getLong("count"));
 				}
 
 				List<IndexMetadata> indexMetadatas = _db.getIndexMetadatas(

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -260,7 +260,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 						companyId)) {
 
-				int rowCount = -1;
+				long rowCount = -1;
 
 				try (PreparedStatement preparedStatement =
 						connection.prepareStatement(
@@ -269,7 +269,7 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
 					if (resultSet.next()) {
-						rowCount = resultSet.getInt("count");
+						rowCount = resultSet.getLong("count");
 					}
 				}
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -256,8 +256,8 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	@TestInfo("LPS-200849")
 	public void testExportAndImportDBPartition() throws Exception {
 		try {
-			int companyCount = _getDefaultSchemaCount("Company");
-			int virtualHostCount = _getDefaultSchemaCount("VirtualHost");
+			long companyCount = _getDefaultSchemaCount("Company");
+			long virtualHostCount = _getDefaultSchemaCount("VirtualHost");
 
 			addDBPartitions();
 			insertPartitionRequiredData();
@@ -624,11 +624,11 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		}
 	}
 
-	private int _getCount(long companyId, String tableName) throws Exception {
+	private long _getCount(long companyId, String tableName) throws Exception {
 		return _getCount(companyId, getPartitionName(companyId), tableName);
 	}
 
-	private int _getCount(
+	private long _getCount(
 			long companyId, String partitionName, String tableName)
 		throws Exception {
 
@@ -646,28 +646,28 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next()) {
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 
 		throw new Exception("Table does not exist");
 	}
 
-	private int _getDefaultSchemaCount(String tableName) throws Exception {
+	private long _getDefaultSchemaCount(String tableName) throws Exception {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select count(1) as count from " + tableName);
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next()) {
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 
 		throw new Exception("Table does not exist");
 	}
 
-	private int _getJobsCount(String partitionName) throws Exception {
+	private long _getJobsCount(String partitionName) throws Exception {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select count(1) as count from " + partitionName +
 					".QUARTZ_JOB_DETAILS where JOB_GROUP = ?")) {
@@ -676,7 +676,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				if (resultSet.next()) {
-					return resultSet.getInt("count");
+					return resultSet.getLong("count");
 				}
 			}
 		}
@@ -684,7 +684,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		throw new Exception("Table does not exist");
 	}
 
-	private int _getJobsCountByCompany(long companyId) throws Exception {
+	private long _getJobsCountByCompany(long companyId) throws Exception {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				StringBundler.concat(
 					"select count(1) as count from ",
@@ -697,7 +697,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				if (resultSet.next()) {
-					return resultSet.getInt("count");
+					return resultSet.getLong("count");
 				}
 			}
 		}
@@ -726,7 +726,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		return objectNames;
 	}
 
-	private int _getQuartzTableCount(long companyId, String tableName)
+	private long _getQuartzTableCount(long companyId, String tableName)
 		throws Exception {
 
 		String whereClause = null;
@@ -747,7 +747,7 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			if (resultSet.next()) {
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableTest.java
@@ -75,10 +75,10 @@ public class UpgradePartitionedControlTableTest
 							ResultSet resultSet =
 								preparedStatement.executeQuery()) {
 
-							int count = 0;
+							long count = 0;
 
 							if (resultSet.next()) {
-								count = resultSet.getInt("count");
+								count = resultSet.getLong("count");
 							}
 
 							Assert.assertEquals(1, count);

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -793,7 +793,7 @@ public class UpgradeReport {
 
 						if (resultSet2.next()) {
 							tableCounts.put(
-								tableName, (long)resultSet2.getInt("count"));
+								tableName, resultSet2.getLong("count"));
 						}
 					}
 					catch (SQLException sqlException) {

--- a/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
@@ -176,7 +176,7 @@ public class UpgradeReportTest {
 		);
 
 		Mockito.when(
-			countResultSet.getLong(1)
+			countResultSet.getLong("count")
 		).thenReturn(
 			3000000000L
 		);

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUuidUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUuidUpgradeProcessTest.java
@@ -66,7 +66,7 @@ public class BaseUuidUpgradeProcessTest extends BaseUuidUpgradeProcess {
 		return new String[] {"TestTable1", "TestTable2"};
 	}
 
-	private int _getDistinctUuidCount(String tableName) throws Exception {
+	private long _getDistinctUuidCount(String tableName) throws Exception {
 		try (Connection connection = DataAccess.getConnection();
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -75,7 +75,7 @@ public class BaseUuidUpgradeProcessTest extends BaseUuidUpgradeProcess {
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				resultSet.next();
 
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 	}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DeleteDuplicateUniqueFinderRowsUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DeleteDuplicateUniqueFinderRowsUpgradeProcessTest.java
@@ -235,7 +235,7 @@ public class DeleteDuplicateUniqueFinderRowsUpgradeProcessTest {
 			if (!duplicatesRemoved) {
 				Assert.assertTrue(resultSet.next());
 
-				Assert.assertEquals(2, resultSet.getInt("count"));
+				Assert.assertEquals(2, resultSet.getLong("count"));
 
 				return;
 			}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/ClassNameUpgradeProcessTest.java
@@ -496,7 +496,7 @@ public class ClassNameUpgradeProcessTest {
 		return fileEntryMetadataId;
 	}
 
-	private int _count(String table, String column, long structureId)
+	private long _count(String table, String column, long structureId)
 		throws Exception {
 
 		try (PreparedStatement preparedStatement = _connection.prepareStatement(
@@ -509,7 +509,7 @@ public class ClassNameUpgradeProcessTest {
 			ResultSet resultSet = preparedStatement.executeQuery();
 
 			if (resultSet.next()) {
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 
@@ -576,21 +576,21 @@ public class ClassNameUpgradeProcessTest {
 		return 0;
 	}
 
-	private int _getDDMStructureRelatedTablesCount(
+	private long _getDDMStructureRelatedTablesCount(
 			long structureId, long structureVersionId)
 		throws Exception {
 
-		int dlFileEntryMetadataCount = _count(
+		long dlFileEntryMetadataCount = _count(
 			"DLFileEntryMetadata", "DDMStructureId", structureId);
-		int ddmFieldCount = _count(
+		long ddmFieldCount = _count(
 			"DDMField", "structureVersionId", structureVersionId);
-		int ddmStorageLinkCount = _count(
+		long ddmStorageLinkCount = _count(
 			"DDMStorageLink", "structureId", structureId);
-		int ddmStructureLayoutCount = _count(
+		long ddmStructureLayoutCount = _count(
 			"DDMStructureLayout", "structureVersionId", structureVersionId);
-		int ddmStructureLinkCount = _count(
+		long ddmStructureLinkCount = _count(
 			"DDMStructureLink", "structureId", structureId);
-		int ddmStructureVersionCount = _count(
+		long ddmStructureVersionCount = _count(
 			"DDMStructureVersion", "structureId", structureId);
 
 		return dlFileEntryMetadataCount + ddmFieldCount + ddmStorageLinkCount +

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v1_1_4/UpgradeClassNames.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v1_1_4/UpgradeClassNames.java
@@ -47,7 +47,7 @@ public class UpgradeClassNames extends UpgradeKernelPackage {
 				ResultSet resultSet1 = preparedStatement1.executeQuery()) {
 
 				if (resultSet1.next()) {
-					if (resultSet1.getInt("count") <= 1) {
+					if (resultSet1.getLong("count") <= 1) {
 						continue;
 					}
 

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ResultSetGetCallCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/checkstyle/check/ResultSetGetCallCheck.java
@@ -85,7 +85,7 @@ public class ResultSetGetCallCheck extends BaseCheck {
 
 			String text = firstChildDetailAST.getText();
 
-			if (methodName.equals("getLong") && text.equals("\"count\"")) {
+			if (methodName.equals("getInt") && text.equals("\"count\"")) {
 				log(firstChildDetailAST, _MSG_METHOD_USE);
 
 				continue;

--- a/modules/util/source-formatter/src/main/resources/checkstyle.xml
+++ b/modules/util/source-formatter/src/main/resources/checkstyle.xml
@@ -822,7 +822,7 @@
 			<property name="category" value="Bug Prevention" />
 			<property name="description" value="Finds incorrect use of `ResultSet.get*` calls." />
 			<property name="enabled" value="false" />
-			<message key="method.use" value="Use &quot;resultSet.getInt&quot; for count" />
+			<message key="method.use" value="Use &quot;resultSet.getLong&quot; for count" />
 			<message key="set.call.parameter.incorrect.1" value="Use the simple column name instead of column index when calling method &quot;resultSet.get*&quot;" />
 			<message key="set.call.parameter.incorrect.2" value="Use the simple column name instead of &quot;TableName.ColumnName&quot; when calling method &quot;resultSet.get*&quot;" />
 		</module>

--- a/modules/util/source-formatter/src/main/resources/documentation/check/result_set_get_call_check.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/check/result_set_get_call_check.md
@@ -1,13 +1,9 @@
 ## ResultSetGetCallCheck
 
-When calling `java.sql.Connection.prepareStatement(String sql)` with `sql` of
-the format `select count(*)`, we should use the type `int` when retrieving the
-value for `count` instead of `long`.
+Using `resultSet.getInt("count")` for a count result is risky as it will fail
+if the value exceeds the int range.
 
-The call `long count = recordSet.getLong(1)` will fail with a
-`java.lang.ClassCastException`.
-
-See <https://liferay.atlassian.net/browse/LPSA-19410>.
+It's safer to use `resultSet.getLong("count")` instead.
 
 ### Example
 
@@ -20,7 +16,7 @@ PreparedStatement preparedStatement =
 ResultSet resultSet = preparedStatement.executeQuery();
 
 if (resultSet.next()) {
-    long count = resultSet.getLong("count");
+    int count = resultSet.getInt("count");
 }
 ```
 
@@ -33,7 +29,7 @@ PreparedStatement preparedStatement =
 ResultSet resultSet = preparedStatement.executeQuery();
 
 if (resultSet.next()) {
-    int count = resultSet.getInt("count");
+    long count = resultSet.getLong("count");
 }
 ```
 
@@ -47,12 +43,12 @@ Incorrect:
 
 ```java
 PreparedStatement preparedStatement =
-    connection.prepareStatement("select count(*) as count from Table");
+    connection.prepareStatement("select count(*) from Table");
 
 ResultSet resultSet = preparedStatement.executeQuery();
 
 if (resultSet.next()) {
-    int count = resultSet.getInt(1);
+    long count = resultSet.getLong(1);
 }
 ```
 
@@ -65,6 +61,6 @@ PreparedStatement preparedStatement =
 ResultSet resultSet = preparedStatement.executeQuery();
 
 if (resultSet.next()) {
-    int count = resultSet.getInt("count");
+    long count = resultSet.getLong("count");
 }
 ```

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -879,7 +879,7 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 					"calling method \"resultSet.get*\"",
 				60
 			).addExpectedMessage(
-				"Use \"resultSet.getInt\" for count", 74
+				"Use \"resultSet.getLong\" for count", 74
 			));
 	}
 

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/ResultSetGetCall.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/ResultSetGetCall.testjava
@@ -71,7 +71,7 @@ public class ResultSetGetCall {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
-				System.out.println(resultSet.getLong("count"));
+				System.out.println(resultSet.getInt("count"));
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
@@ -499,7 +499,7 @@ public class PortalUpgradeProcess extends UpgradeProcess {
 			preparedStatement.setString(2, testString);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (resultSet.next() && (resultSet.getInt("count") > 0)) {
+				if (resultSet.next() && (resultSet.getLong("count") > 0)) {
 					return true;
 				}
 			}

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_1/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_1/UpgradeDocumentLibrary.java
@@ -38,7 +38,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_1/UpgradeLayout.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_1/UpgradeLayout.java
@@ -56,7 +56,7 @@ public class UpgradeLayout extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java
@@ -1329,7 +1329,7 @@ public class UpgradeJournal extends BaseUpgradePortletPreferences {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return false;
 					}
 				}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -127,7 +127,7 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					if (resultSet.getInt("count") > 0) {
+					if (resultSet.getLong("count") > 0) {
 						return true;
 					}
 				}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSubscription.java
@@ -151,7 +151,7 @@ public class UpgradeSubscription extends UpgradeProcess {
 			preparedStatement.setLong(1, groupId);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (resultSet.next() && (resultSet.getInt("count") > 0)) {
+				if (resultSet.next() && (resultSet.getLong("count") > 0)) {
 					return true;
 				}
 			}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/ClassNameUpgradeProcess.java
@@ -60,7 +60,7 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 				continue;
 			}
 
-			int oldDLFileEntryMetadatasCount = _getDLFileEntryMetadatasCount(
+			long oldDLFileEntryMetadatasCount = _getDLFileEntryMetadatasCount(
 				oldStructureId);
 
 			if (oldDLFileEntryMetadatasCount == 0) {
@@ -73,7 +73,7 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 
 			long newStructureId = newDDMStructureValues[1];
 
-			int newDLFileEntryMetadatasCount = _getDLFileEntryMetadatasCount(
+			long newDLFileEntryMetadatasCount = _getDLFileEntryMetadatasCount(
 				newStructureId);
 
 			if (newDLFileEntryMetadatasCount == 0) {
@@ -225,7 +225,7 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 		return 0;
 	}
 
-	private int _getDLFileEntryMetadatasCount(long structureId)
+	private long _getDLFileEntryMetadatasCount(long structureId)
 		throws Exception {
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
@@ -237,7 +237,7 @@ public class ClassNameUpgradeProcess extends UpgradeProcess {
 			ResultSet resultSet = preparedStatement.executeQuery();
 
 			if (resultSet.next()) {
-				return resultSet.getInt("count");
+				return resultSet.getLong("count");
 			}
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -216,7 +216,7 @@ public class DBInspector {
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			while (resultSet.next()) {
-				if (resultSet.getInt("count") > 0) {
+				if (resultSet.getLong("count") > 0) {
 					return true;
 				}
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -100,7 +100,7 @@ public class UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 
 			while (resultSet.next()) {
 				long companyId = resultSet.getLong("companyId");
-				long count = resultSet.getInt("count");
+				long count = resultSet.getLong("count");
 				long userId = resultSet.getLong(sourceColumnName);
 
 				if (_deleteTableNames.contains(sourceTableName) ||

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
@@ -124,7 +124,7 @@ public class OrphanReferencesDataCleanupUtil {
 
 			while (resultSet.next()) {
 				DataCleanupLoggingUtil.logDelete(
-					_log, resultSet.getInt("count"), readOnly, sourceTableName,
+					_log, resultSet.getLong("count"), readOnly, sourceTableName,
 					StringBundler.concat(
 						sourceColumnName, StringPool.SPACE,
 						resultSet.getObject(sourceColumnName),


### PR DESCRIPTION
See https://github.com/liferay-database-infra/liferay-portal/pull/3459#issuecomment-4215212330
> [jorgediaz-lr](https://github.com/jorgediaz-lr)commented[17 hours ago](https://github.com/liferay-database-infra/liferay-portal/pull/3459#issuecomment-4215212330)

> Hi @ling-alan-huang
> 
> I analyzed it and it seems https://liferay.atlassian.net/browse/LPSA-19410 was a very old bug (2012) for SQL Server JDBC driver.
> In fact after https://liferay.atlassian.net/browse/LPD-76503 bug were postgresql complained in the opposite way, I think we have to change this SF rule to force using getLong("count")
> 
> @ling-alan-huang can we change the SF rule to force using getLong and replace the LPSA-19410 references with LPD-76503 instead?
> 
> Thank you

> [IstvanD](https://github.com/IstvanD)commented[1 hour ago](https://github.com/liferay-devtools/liferay-portal/pull/799#issue-4237358338)
> This SF rule ResultSetGetCallCheck is breaking the UpgradeReportTest > testGetTableCounts test that was added after fixing https://liferay.atlassian.net/browse/LPD-76503.
> 
> getInt is not recommended for getting the count results if the table is huge and has millions of results.
> 
> The SF rule should be fixed so the changes can be merged.