### PR TITLE
LPD-85235 Fix testGetTableCounts overflow in UpgradeReport

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -793,7 +793,7 @@ public class UpgradeReport {
 
 						if (resultSet2.next()) {
 							tableCounts.put(
-								tableName, (long)resultSet2.getInt("count"));
+								tableName, resultSet2.getLong("count"));
 						}
 					}
 					catch (SQLException sqlException) {

--- a/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
@@ -176,7 +176,7 @@ public class UpgradeReportTest {
 		);
 
 		Mockito.when(
-			countResultSet.getLong(1)
+			countResultSet.getLong("count")
 		).thenReturn(
 			3000000000L
 		);


### PR DESCRIPTION
This SF rule `ResultSetGetCallCheck` is breaking the `UpgradeReportTest > testGetTableCounts` test that was added after fixing https://liferay.atlassian.net/browse/LPD-76503.

`getInt` is not recommended for getting the count results if the table is huge and has millions of results.

The SF rule should be fixed so the changes can be merged.

@ling-alan-huang
@liferay-database-infra