### PR TITLE
LPD-86257 Investigate sporadic failures in headless-discovery-web:packageRunBuild

### DIFF
--- a/modules/apps/frontend-js/frontend-js-clay-web/build.gradle
+++ b/modules/apps/frontend-js/frontend-js-clay-web/build.gradle
@@ -11,5 +11,8 @@ dependencies {
 }
 
 packageRunBuild {
-	inputs.dir "clay"
+	inputs.files fileTree("clay") {
+		exclude "clay-css/lib/**"
+	}
+	outputs.dir "clay/clay-css/lib"
 }


### PR DESCRIPTION
This is an update for [LPD-86257](https://liferay.atlassian.net/browse/LPD-86257).

Explanation with Claude's help:

## TL;DR

`frontend-js-clay-web`'s `packageRunBuild` task is `@CacheableTask` but didn't declare `clay/clay-css/lib` as an output. When CI loaded it `FROM-CACHE`, nothing was restored into `clay-css/lib/` — so downstream builds that import `@clayui/css/lib/css/atlas.css` via the yarn workspace symlink failed.

**Fix** in `modules/apps/frontend-js/frontend-js-clay-web/build.gradle`:

```groovy
packageRunBuild {
    inputs.files fileTree("clay") {
        exclude "clay-css/lib/**"
    }
    outputs.dir "clay/clay-css/lib"
}
```

## Validate for yourself

```bash
# Populate the cache
rm -rf modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/lib
gw :apps:frontend-js:frontend-js-clay-web:packageRunBuild \
    --rerun --build-cache

# Simulate CI (fresh checkout, yarnInstall SKIPPED, clay-web FROM-CACHE)
rm -rf modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/lib
gw :apps:headless:headless-discovery:headless-discovery-web:packageRunBuild \
    --rerun -x :yarnInstall --build-cache
```

- **Without the fix**: `clay-web:packageRunBuild FROM-CACHE`, then `✘ Could not resolve "@clayui/css/lib/css/atlas.css"` — exactly the CI failure.
- **With the fix**: same `FROM-CACHE` on clay-web, but now `lib/` is actually restored, and the downstream build succeeds.

The clay-web task state (`FROM-CACHE`) is identical in both runs — the only difference is whether Gradle has an output directory to restore.

## Why this shape

- `@clayui/css` is a yarn workspace symlink: `modules/node_modules/@clayui/css` → `apps/frontend-js/frontend-js-clay-web/clay/clay-css/`. esbuild follows that symlink to find `lib/css/atlas.css`.
- `clay-css`'s build script writes into the source tree at `clay-css/lib/` rather than a Gradle `build/` dir, which is the root cause of the cache mismatch.
- Locally this is masked because `yarn install` runs clay-css's `prepublish` hook on every install, regenerating `lib/`. On CI both `:yarnInstall` is SKIPPED and `clay-web:packageRunBuild` is restored FROM-CACHE — neither path repopulates `lib/`.

Key decisions in the fix:

1. **`outputs.dir "clay/clay-css/lib"`** — a single, concrete directory. Gradle caches and restores it as a unit.
2. **`inputs.files fileTree(...) { exclude "clay-css/lib/**" }`** — without the exclude, `lib/` would be both an input (via `inputs.dir "clay"`) and an output, which is the exact overlap [Gradle tells you not to create](https://docs.gradle.org/current/userguide/common_caching_problems.html) ("make sure you do not create overlapping outputs for cacheable tasks"). Excluding the output from inputs keeps the territories disjoint.
3. **Why not a broader `fileTree(include "clay-*/lib/**")` for outputs?** Tested and rejected — Gradle treats the `fileTree` root (`clay/`) as output-owned territory regardless of the include pattern, sees non-lib files it didn't create, and **silently disables caching for the whole task** (surfaces only under `gradle -i` as *"Gradle does not know how file 'clay' was created"*). Only `clay-css` actually emits to `lib/` today — narrow is honest.

## If a new clay-* package starts building to `lib/`

Add another line:

```groovy
outputs.dir "clay/clay-<new-package>/lib"
// and extend the exclude: exclude "clay-css/lib/**", "clay-<new-package>/lib/**"
```

One-line-per-package is intentional: each new declaration is visible in review.
