### PR TITLE
LPD-87765 Delete persisted CET configurations on upgrade

### DIFF
--- a/modules/apps/client-extension/client-extension-service/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension Service
 Bundle-SymbolicName: com.liferay.client.extension.service
-Bundle-Version: 1.0.68
+Bundle-Version: 1.0.69
 Liferay-Require-SchemaVersion: 3.5.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/client-extension/client-extension-service/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension Service
 Bundle-SymbolicName: com.liferay.client.extension.service
 Bundle-Version: 1.0.68
-Liferay-Require-SchemaVersion: 3.5.1
+Liferay-Require-SchemaVersion: 3.5.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/registry/ClientExtensionUpgradeStepRegistrator.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/registry/ClientExtensionUpgradeStepRegistrator.java
@@ -7,6 +7,7 @@ package com.liferay.client.extension.internal.upgrade.registry;
 
 import com.liferay.client.extension.internal.upgrade.v3_0_0.ClassNamesUpgradeProcess;
 import com.liferay.client.extension.internal.upgrade.v3_1_0.util.ClientExtensionEntryRelTable;
+import com.liferay.client.extension.internal.upgrade.v3_5_2.CETConfigurationUpgradeProcess;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
@@ -15,6 +16,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.release.ReleaseRenamingUpgradeStep;
 
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -110,7 +112,14 @@ public class ClientExtensionUpgradeStepRegistrator
 				"lastPublishDate DATE null"));
 
 		registry.register("3.5.0", "3.5.1", new DummyUpgradeProcess());
+
+		registry.register(
+			"3.5.1", "3.5.2",
+			new CETConfigurationUpgradeProcess(_configurationAdmin));
 	}
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/registry/ClientExtensionUpgradeStepRegistrator.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/registry/ClientExtensionUpgradeStepRegistrator.java
@@ -16,7 +16,6 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.portal.upgrade.release.ReleaseRenamingUpgradeStep;
 
-import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -114,12 +113,8 @@ public class ClientExtensionUpgradeStepRegistrator
 		registry.register("3.5.0", "3.5.1", new DummyUpgradeProcess());
 
 		registry.register(
-			"3.5.1", "3.5.2",
-			new CETConfigurationUpgradeProcess(_configurationAdmin));
+			"3.5.1", "3.5.2", new CETConfigurationUpgradeProcess());
 	}
-
-	@Reference
-	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
 	private ReleaseLocalService _releaseLocalService;

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -32,8 +32,9 @@ public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 				StringBundler.concat(
 					"select configurationId from Configuration_ where ",
 					"configurationId like 'com.liferay.client.extension.type.",
-					"configuration.CETConfiguration~%' and dictionary not ",
-					"like '%.client.extension.config.bundle.id=%'"));
+					"configuration.CETConfiguration~%' and (dictionary is ",
+					"null or dictionary not like ",
+					"'%.client.extension.config.bundle.id=%')"));
 
 			PreparedStatement preparedStatement =
 				AutoBatchPreparedStatementUtil.autoBatch(

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -15,6 +15,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Anthony Chu
  */
@@ -26,6 +29,8 @@ public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 			return;
 		}
 
+		List<String> configurationIds = new ArrayList<>();
+
 		try (Statement statement = connection.createStatement();
 
 			ResultSet resultSet = statement.executeQuery(
@@ -34,16 +39,23 @@ public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 					"configurationId like 'com.liferay.client.extension.type.",
 					"configuration.CETConfiguration~%' and (dictionary is ",
 					"null or dictionary not like ",
-					"'%.client.extension.config.bundle.id=%')"));
+					"'%.client.extension.config.bundle.id=%')"))) {
 
-			PreparedStatement preparedStatement =
+			while (resultSet.next()) {
+				configurationIds.add(resultSet.getString("configurationId"));
+			}
+		}
+
+		if (configurationIds.isEmpty()) {
+			return;
+		}
+
+		try (PreparedStatement preparedStatement =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"delete from Configuration_ where configurationId = ?")) {
 
-			while (resultSet.next()) {
-				String configurationId = resultSet.getString("configurationId");
-
+			for (String configurationId : configurationIds) {
 				if (_log.isInfoEnabled()) {
 					_log.info(
 						"Deleting persisted CET configuration " +

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.internal.upgrade.v3_5_2;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import org.osgi.framework.Constants;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Anthony Chu
+ */
+public class CETConfigurationUpgradeProcess extends UpgradeProcess {
+
+	public CETConfigurationUpgradeProcess(
+		ConfigurationAdmin configurationAdmin) {
+
+		_configurationAdmin = configurationAdmin;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			StringBundler.concat(
+				"(", Constants.SERVICE_PID,
+				"=com.liferay.client.extension.type.configuration.",
+				"CETConfiguration~*)"));
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			configuration.delete();
+		}
+	}
+
+	private final ConfigurationAdmin _configurationAdmin;
+
+}

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -6,52 +6,59 @@
 package com.liferay.client.extension.internal.upgrade.v3_5_2;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
-import org.osgi.framework.Constants;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
 
 /**
  * @author Anthony Chu
  */
 public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 
-	public CETConfigurationUpgradeProcess(
-		ConfigurationAdmin configurationAdmin) {
-
-		_configurationAdmin = configurationAdmin;
-	}
-
 	@Override
 	protected void doUpgrade() throws Exception {
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			StringBundler.concat(
-				"(&(", Constants.SERVICE_PID,
-				"=com.liferay.client.extension.type.configuration.",
-				"CETConfiguration~*)",
-				"(!(.client.extension.config.bundle.id=*)))"));
-
-		if (configurations == null) {
+		if (!hasTable("Configuration_")) {
 			return;
 		}
 
-		for (Configuration configuration : configurations) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					"Deleting orphaned CET configuration " +
-						configuration.getPid());
+		try (Statement statement = connection.createStatement();
+
+			ResultSet resultSet = statement.executeQuery(
+				StringBundler.concat(
+					"select configurationId from Configuration_ where ",
+					"configurationId like 'com.liferay.client.extension.type.",
+					"configuration.CETConfiguration~%' and dictionary not ",
+					"like '%.client.extension.config.bundle.id=%'"));
+
+			PreparedStatement preparedStatement =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"delete from Configuration_ where configurationId = ?")) {
+
+			while (resultSet.next()) {
+				String configurationId = resultSet.getString("configurationId");
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						"Deleting persisted CET configuration " +
+							configurationId);
+				}
+
+				preparedStatement.setString(1, configurationId);
+
+				preparedStatement.addBatch();
 			}
 
-			configuration.delete();
+			preparedStatement.executeBatch();
 		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CETConfigurationUpgradeProcess.class);
-
-	private final ConfigurationAdmin _configurationAdmin;
 
 }

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -6,6 +6,8 @@
 package com.liferay.client.extension.internal.upgrade.v3_5_2;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 import org.osgi.framework.Constants;
@@ -29,16 +31,26 @@ public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 			StringBundler.concat(
 				"(&(", Constants.SERVICE_PID,
 				"=com.liferay.client.extension.type.configuration.",
-				"CETConfiguration~*)(!(.client.extension.config.bundle.id=*)))"));
+				"CETConfiguration~*)",
+				"(!(.client.extension.config.bundle.id=*)))"));
 
 		if (configurations == null) {
 			return;
 		}
 
 		for (Configuration configuration : configurations) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Deleting orphaned CET configuration " +
+						configuration.getPid());
+			}
+
 			configuration.delete();
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CETConfigurationUpgradeProcess.class);
 
 	private final ConfigurationAdmin _configurationAdmin;
 

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -27,9 +27,9 @@ public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		Configuration[] configurations = _configurationAdmin.listConfigurations(
 			StringBundler.concat(
-				"(", Constants.SERVICE_PID,
+				"(&(", Constants.SERVICE_PID,
 				"=com.liferay.client.extension.type.configuration.",
-				"CETConfiguration~*)"));
+				"CETConfiguration~*)(!(.client.extension.config.bundle.id=*)))"));
 
 		if (configurations == null) {
 			return;

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -6,17 +6,11 @@
 package com.liferay.client.extension.internal.upgrade.v3_5_2;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.Statement;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author Anthony Chu
@@ -29,45 +23,21 @@ public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 			return;
 		}
 
-		List<String> configurationIds = new ArrayList<>();
-
-		try (Statement statement = connection.createStatement();
-
-			ResultSet resultSet = statement.executeQuery(
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				StringBundler.concat(
-					"select configurationId from Configuration_ where ",
-					"configurationId like 'com.liferay.client.extension.type.",
-					"configuration.CETConfiguration~%' and (dictionary is ",
-					"null or dictionary not like ",
+					"delete from Configuration_ where configurationId like ",
+					"'com.liferay.client.extension.type.configuration.",
+					"CETConfiguration~%' and (dictionary is null or ",
+					"dictionary not like ",
 					"'%.client.extension.config.bundle.id=%')"))) {
 
-			while (resultSet.next()) {
-				configurationIds.add(resultSet.getString("configurationId"));
+			int deletedCount = preparedStatement.executeUpdate();
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Deleted " + deletedCount +
+						" persisted CET configurations");
 			}
-		}
-
-		if (configurationIds.isEmpty()) {
-			return;
-		}
-
-		try (PreparedStatement preparedStatement =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					"delete from Configuration_ where configurationId = ?")) {
-
-			for (String configurationId : configurationIds) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						"Deleting persisted CET configuration " +
-							configurationId);
-				}
-
-				preparedStatement.setString(1, configurationId);
-
-				preparedStatement.addBatch();
-			}
-
-			preparedStatement.executeBatch();
 		}
 	}
 

--- a/modules/apps/client-extension/client-extension-test/build.gradle
+++ b/modules/apps/client-extension/client-extension-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -47,11 +47,7 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 	public void tearDown() throws Exception {
 		DB db = DBManagerUtil.getDB();
 
-		db.runSQL(
-			StringBundler.concat(
-				"delete from Configuration_ where configurationId in ('",
-				_STALE_CET_PID_1, "', '", _STALE_CET_PID_2, "', '",
-				_TRACKER_CET_PID, "', '", _UNRELATED_PID, "')"));
+		db.runSQL("delete from Configuration_ where " + _pidsInClause());
 	}
 
 	@Test
@@ -74,11 +70,8 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 			Statement statement = connection.createStatement();
 
 			ResultSet resultSet = statement.executeQuery(
-				StringBundler.concat(
-					"select configurationId from Configuration_ where ",
-					"configurationId in ('", _STALE_CET_PID_1, "', '",
-					_STALE_CET_PID_2, "', '", _TRACKER_CET_PID, "', '",
-					_UNRELATED_PID, "')"))) {
+				"select configurationId from Configuration_ where " +
+					_pidsInClause())) {
 
 			Set<String> survivingPids = new HashSet<>();
 
@@ -106,6 +99,12 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 			preparedStatement.execute();
 		}
+	}
+
+	private String _pidsInClause() {
+		return StringBundler.concat(
+			"configurationId in ('", _STALE_CET_PID_1, "', '", _STALE_CET_PID_2,
+			"', '", _TRACKER_CET_PID, "', '", _UNRELATED_PID, "')");
 	}
 
 	private static final String _CET_CONFIGURATION_PID_PREFIX =

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -11,16 +11,14 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-
-import java.util.Objects;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -59,11 +57,10 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 			_TRACKER_CET_PID, ".client.extension.config.bundle.id=L\"1\"\n");
 		_insertConfiguration(_UNRELATED_PID, "");
 
-		UpgradeProcess upgradeProcess = _getUpgradeProcess();
-
-		Assert.assertNotNull(
-			"CET configuration cleanup upgrade step must be registered",
-			upgradeProcess);
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.client.extension.internal.upgrade.v3_5_2." +
+				"CETConfigurationUpgradeProcess");
 
 		upgradeProcess.upgrade();
 
@@ -96,34 +93,6 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 		}
 	}
 
-	private UpgradeProcess _getUpgradeProcess() {
-		UpgradeProcess[] upgradeProcesses = new UpgradeProcess[1];
-
-		_upgradeStepRegistrator.register(
-			(fromSchemaVersionString, toSchemaVersionString, upgradeSteps) -> {
-				if (!Objects.equals(fromSchemaVersionString, "3.5.1") ||
-					!Objects.equals(toSchemaVersionString, "3.5.2")) {
-
-					return;
-				}
-
-				for (UpgradeStep upgradeStep : upgradeSteps) {
-					Class<?> upgradeStepClass = upgradeStep.getClass();
-
-					if (Objects.equals(
-							upgradeStepClass.getName(),
-							_CLASS_NAME_CET_CONFIGURATION_UPGRADE_PROCESS)) {
-
-						upgradeProcesses[0] = (UpgradeProcess)upgradeStep;
-
-						return;
-					}
-				}
-			});
-
-		return upgradeProcesses[0];
-	}
-
 	private void _insertConfiguration(String pid, String dictionary)
 		throws Exception {
 
@@ -142,10 +111,6 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 	private static final String _CET_CONFIGURATION_PID_PREFIX =
 		"com.liferay.client.extension.type.configuration.CETConfiguration~";
-
-	private static final String _CLASS_NAME_CET_CONFIGURATION_UPGRADE_PROCESS =
-		"com.liferay.client.extension.internal.upgrade.v3_5_2." +
-			"CETConfigurationUpgradeProcess";
 
 	private static final String _STALE_CET_PID_1 =
 		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-1/liferay.com";

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -42,14 +42,22 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 	public void tearDown() throws Exception {
 		_deleteConfiguration(_STALE_CET_PID_1);
 		_deleteConfiguration(_STALE_CET_PID_2);
+		_deleteConfiguration(_TRACKER_CET_PID);
 		_deleteConfiguration(_UNRELATED_PID);
 	}
 
 	@Test
 	public void testUpgrade() throws Exception {
-		_createConfiguration(_STALE_CET_PID_1);
-		_createConfiguration(_STALE_CET_PID_2);
-		_createConfiguration(_UNRELATED_PID);
+		_createConfiguration(_STALE_CET_PID_1, new Hashtable<>());
+		_createConfiguration(_STALE_CET_PID_2, new Hashtable<>());
+
+		Hashtable<String, Object> trackerProperties = new Hashtable<>();
+
+		trackerProperties.put(_BUNDLE_ID_PROPERTY_KEY, 1L);
+
+		_createConfiguration(_TRACKER_CET_PID, trackerProperties);
+
+		_createConfiguration(_UNRELATED_PID, new Hashtable<>());
 
 		Configuration[] cetConfigurationsBeforeUpgrade =
 			_configurationAdmin.listConfigurations(
@@ -58,11 +66,12 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 					_CET_CONFIGURATION_PID_PREFIX, "*)"));
 
 		Assert.assertNotNull(
-			"Stale CET configurations must exist before upgrade",
+			"CET configurations must exist before upgrade",
 			cetConfigurationsBeforeUpgrade);
 		Assert.assertEquals(
-			"Two stale CET configurations must exist before upgrade", 2,
-			cetConfigurationsBeforeUpgrade.length);
+			"Two stale and one tracker-installed CET configuration must " +
+				"exist before upgrade",
+			3, cetConfigurationsBeforeUpgrade.length);
 
 		UpgradeProcess upgradeProcess = _getUpgradeProcess();
 
@@ -72,12 +81,21 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 		upgradeProcess.upgrade();
 
-		Assert.assertNull(
-			"All stale CET configurations should be deleted",
+		Configuration[] cetConfigurationsAfterUpgrade =
 			_configurationAdmin.listConfigurations(
 				StringBundler.concat(
 					"(", Constants.SERVICE_PID, "=",
-					_CET_CONFIGURATION_PID_PREFIX, "*)")));
+					_CET_CONFIGURATION_PID_PREFIX, "*)"));
+
+		Assert.assertNotNull(
+			"Tracker-installed CET configuration must survive upgrade",
+			cetConfigurationsAfterUpgrade);
+		Assert.assertEquals(
+			"Only the tracker-installed CET configuration should remain", 1,
+			cetConfigurationsAfterUpgrade.length);
+		Assert.assertEquals(
+			_TRACKER_CET_PID, cetConfigurationsAfterUpgrade[0].getPid());
+
 		Assert.assertNotNull(
 			"Unrelated configuration should survive",
 			_configurationAdmin.listConfigurations(
@@ -85,11 +103,14 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 					"(", Constants.SERVICE_PID, "=", _UNRELATED_PID, ")")));
 	}
 
-	private void _createConfiguration(String pid) throws Exception {
+	private void _createConfiguration(
+			String pid, Hashtable<String, Object> properties)
+		throws Exception {
+
 		Configuration configuration = _configurationAdmin.getConfiguration(
 			pid, "?");
 
-		configuration.update(new Hashtable<>());
+		configuration.update(properties);
 	}
 
 	private void _deleteConfiguration(String pid) throws Exception {
@@ -133,6 +154,9 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 		return upgradeProcesses[0];
 	}
 
+	private static final String _BUNDLE_ID_PROPERTY_KEY =
+		".client.extension.config.bundle.id";
+
 	private static final String _CET_CONFIGURATION_PID_PREFIX =
 		"com.liferay.client.extension.type.configuration.CETConfiguration~";
 
@@ -145,6 +169,9 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 	private static final String _STALE_CET_PID_2 =
 		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-2/liferay.com";
+
+	private static final String _TRACKER_CET_PID =
+		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-tracker/liferay.com";
 
 	private static final String _UNRELATED_PID =
 		"com.liferay.client.extension.upgrade.test.unrelated";

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -53,7 +53,7 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 	@Test
 	public void testUpgrade() throws Exception {
 		_insertConfiguration(_STALE_CET_PID_1, "");
-		_insertConfiguration(_STALE_CET_PID_2, "");
+		_insertConfiguration(_STALE_CET_PID_2, null);
 		_insertConfiguration(
 			_TRACKER_CET_PID, ".client.extension.config.bundle.id=L\"1\"\n");
 		_insertConfiguration(_UNRELATED_PID, "");

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -7,13 +7,19 @@ package com.liferay.client.extension.upgrade.v3_5_2.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
-import java.util.Hashtable;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
 import java.util.Objects;
 
 import org.junit.After;
@@ -22,10 +28,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Constants;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Anthony Chu
@@ -40,38 +42,22 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 	@After
 	public void tearDown() throws Exception {
-		_deleteConfiguration(_STALE_CET_PID_1);
-		_deleteConfiguration(_STALE_CET_PID_2);
-		_deleteConfiguration(_TRACKER_CET_PID);
-		_deleteConfiguration(_UNRELATED_PID);
+		DB db = DBManagerUtil.getDB();
+
+		db.runSQL(
+			StringBundler.concat(
+				"delete from Configuration_ where configurationId in ('",
+				_STALE_CET_PID_1, "', '", _STALE_CET_PID_2, "', '",
+				_TRACKER_CET_PID, "', '", _UNRELATED_PID, "')"));
 	}
 
 	@Test
 	public void testUpgrade() throws Exception {
-		_createConfiguration(_STALE_CET_PID_1, new Hashtable<>());
-		_createConfiguration(_STALE_CET_PID_2, new Hashtable<>());
-
-		Hashtable<String, Object> trackerProperties = new Hashtable<>();
-
-		trackerProperties.put(_BUNDLE_ID_PROPERTY_KEY, 1L);
-
-		_createConfiguration(_TRACKER_CET_PID, trackerProperties);
-
-		_createConfiguration(_UNRELATED_PID, new Hashtable<>());
-
-		Configuration[] cetConfigurationsBeforeUpgrade =
-			_configurationAdmin.listConfigurations(
-				StringBundler.concat(
-					"(", Constants.SERVICE_PID, "=",
-					_CET_CONFIGURATION_PID_PREFIX, "*)"));
-
-		Assert.assertNotNull(
-			"CET configurations must exist before upgrade",
-			cetConfigurationsBeforeUpgrade);
-		Assert.assertEquals(
-			"Two stale and one tracker-installed CET configuration must " +
-				"exist before upgrade",
-			3, cetConfigurationsBeforeUpgrade.length);
+		_insertConfiguration(_STALE_CET_PID_1, "");
+		_insertConfiguration(_STALE_CET_PID_2, "");
+		_insertConfiguration(
+			_TRACKER_CET_PID, ".client.extension.config.bundle.id=L\"1\"\n");
+		_insertConfiguration(_UNRELATED_PID, "");
 
 		UpgradeProcess upgradeProcess = _getUpgradeProcess();
 
@@ -81,48 +67,32 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 		upgradeProcess.upgrade();
 
-		Configuration[] cetConfigurationsAfterUpgrade =
-			_configurationAdmin.listConfigurations(
-				StringBundler.concat(
-					"(", Constants.SERVICE_PID, "=",
-					_CET_CONFIGURATION_PID_PREFIX, "*)"));
-
-		Assert.assertNotNull(
+		Assert.assertFalse(
+			"Stale CET configuration must be deleted",
+			_configurationExists(_STALE_CET_PID_1));
+		Assert.assertFalse(
+			"Stale CET configuration must be deleted",
+			_configurationExists(_STALE_CET_PID_2));
+		Assert.assertTrue(
 			"Tracker-installed CET configuration must survive upgrade",
-			cetConfigurationsAfterUpgrade);
-		Assert.assertEquals(
-			"Only the tracker-installed CET configuration should remain", 1,
-			cetConfigurationsAfterUpgrade.length);
-		Assert.assertEquals(
-			_TRACKER_CET_PID, cetConfigurationsAfterUpgrade[0].getPid());
-
-		Assert.assertNotNull(
-			"Unrelated configuration should survive",
-			_configurationAdmin.listConfigurations(
-				StringBundler.concat(
-					"(", Constants.SERVICE_PID, "=", _UNRELATED_PID, ")")));
+			_configurationExists(_TRACKER_CET_PID));
+		Assert.assertTrue(
+			"Unrelated configuration must survive upgrade",
+			_configurationExists(_UNRELATED_PID));
 	}
 
-	private void _createConfiguration(
-			String pid, Hashtable<String, Object> properties)
-		throws Exception {
+	private boolean _configurationExists(String pid) throws Exception {
+		try (Connection connection = DataAccess.getConnection();
 
-		Configuration configuration = _configurationAdmin.getConfiguration(
-			pid, "?");
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select configurationId from Configuration_ where " +
+					"configurationId = ?")) {
 
-		configuration.update(properties);
-	}
+			preparedStatement.setString(1, pid);
 
-	private void _deleteConfiguration(String pid) throws Exception {
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			StringBundler.concat("(", Constants.SERVICE_PID, "=", pid, ")"));
-
-		if (configurations == null) {
-			return;
-		}
-
-		for (Configuration configuration : configurations) {
-			configuration.delete();
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
 		}
 	}
 
@@ -154,8 +124,21 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 		return upgradeProcesses[0];
 	}
 
-	private static final String _BUNDLE_ID_PROPERTY_KEY =
-		".client.extension.config.bundle.id";
+	private void _insertConfiguration(String pid, String dictionary)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"insert into Configuration_ (configurationId, dictionary) " +
+					"values(?, ?)")) {
+
+			preparedStatement.setString(1, pid);
+			preparedStatement.setString(2, dictionary);
+
+			preparedStatement.execute();
+		}
+	}
 
 	private static final String _CET_CONFIGURATION_PID_PREFIX =
 		"com.liferay.client.extension.type.configuration.CETConfiguration~";
@@ -175,9 +158,6 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 	private static final String _UNRELATED_PID =
 		"com.liferay.client.extension.upgrade.test.unrelated";
-
-	@Inject
-	private ConfigurationAdmin _configurationAdmin;
 
 	@Inject(
 		filter = "component.name=com.liferay.client.extension.internal.upgrade.registry.ClientExtensionUpgradeStepRegistrator"

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -1,0 +1,159 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.upgrade.v3_5_2.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+
+import java.util.Hashtable;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Constants;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Anthony Chu
+ */
+@RunWith(Arquillian.class)
+public class CETConfigurationCleanupUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@After
+	public void tearDown() throws Exception {
+		_deleteConfiguration(_STALE_CET_PID_1);
+		_deleteConfiguration(_STALE_CET_PID_2);
+		_deleteConfiguration(_UNRELATED_PID);
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_createConfiguration(_STALE_CET_PID_1);
+		_createConfiguration(_STALE_CET_PID_2);
+		_createConfiguration(_UNRELATED_PID);
+
+		Configuration[] cetConfigurationsBeforeUpgrade =
+			_configurationAdmin.listConfigurations(
+				StringBundler.concat(
+					"(", Constants.SERVICE_PID, "=",
+					_CET_CONFIGURATION_PID_PREFIX, "*)"));
+
+		Assert.assertNotNull(
+			"Stale CET configurations must exist before upgrade",
+			cetConfigurationsBeforeUpgrade);
+		Assert.assertEquals(
+			"Two stale CET configurations must exist before upgrade", 2,
+			cetConfigurationsBeforeUpgrade.length);
+
+		UpgradeProcess upgradeProcess = _getUpgradeProcess();
+
+		Assert.assertNotNull(
+			"CET configuration cleanup upgrade step must be registered",
+			upgradeProcess);
+
+		upgradeProcess.upgrade();
+
+		Assert.assertNull(
+			"All stale CET configurations should be deleted",
+			_configurationAdmin.listConfigurations(
+				StringBundler.concat(
+					"(", Constants.SERVICE_PID, "=",
+					_CET_CONFIGURATION_PID_PREFIX, "*)")));
+		Assert.assertNotNull(
+			"Unrelated configuration should survive",
+			_configurationAdmin.listConfigurations(
+				StringBundler.concat(
+					"(", Constants.SERVICE_PID, "=", _UNRELATED_PID, ")")));
+	}
+
+	private void _createConfiguration(String pid) throws Exception {
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			pid, "?");
+
+		configuration.update(new Hashtable<>());
+	}
+
+	private void _deleteConfiguration(String pid) throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			StringBundler.concat("(", Constants.SERVICE_PID, "=", pid, ")"));
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			configuration.delete();
+		}
+	}
+
+	private UpgradeProcess _getUpgradeProcess() {
+		UpgradeProcess[] upgradeProcesses = new UpgradeProcess[1];
+
+		_upgradeStepRegistrator.register(
+			(fromSchemaVersionString, toSchemaVersionString, upgradeSteps) -> {
+				if (!Objects.equals(fromSchemaVersionString, "3.5.1") ||
+					!Objects.equals(toSchemaVersionString, "3.5.2")) {
+
+					return;
+				}
+
+				for (Object upgradeStep : upgradeSteps) {
+					Class<?> upgradeStepClass = upgradeStep.getClass();
+
+					if (Objects.equals(
+							upgradeStepClass.getName(),
+							_CLASS_NAME_CET_CONFIGURATION_UPGRADE_PROCESS)) {
+
+						upgradeProcesses[0] = (UpgradeProcess)upgradeStep;
+
+						return;
+					}
+				}
+			});
+
+		return upgradeProcesses[0];
+	}
+
+	private static final String _CET_CONFIGURATION_PID_PREFIX =
+		"com.liferay.client.extension.type.configuration.CETConfiguration~";
+
+	private static final String _CLASS_NAME_CET_CONFIGURATION_UPGRADE_PROCESS =
+		"com.liferay.client.extension.internal.upgrade.v3_5_2." +
+			"CETConfigurationUpgradeProcess";
+
+	private static final String _STALE_CET_PID_1 =
+		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-1/liferay.com";
+
+	private static final String _STALE_CET_PID_2 =
+		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-2/liferay.com";
+
+	private static final String _UNRELATED_PID =
+		"com.liferay.client.extension.upgrade.test.unrelated";
+
+	@Inject
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Inject(
+		filter = "component.name=com.liferay.client.extension.internal.upgrade.registry.ClientExtensionUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -8,6 +8,7 @@ package com.liferay.client.extension.upgrade.v3_5_2.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -115,7 +116,7 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 					return;
 				}
 
-				for (Object upgradeStep : upgradeSteps) {
+				for (UpgradeStep upgradeStep : upgradeSteps) {
 					Class<?> upgradeStepClass = upgradeStep.getClass();
 
 					if (Objects.equals(

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationCleanupUpgradeProcessTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -19,6 +20,10 @@ import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -64,32 +69,26 @@ public class CETConfigurationCleanupUpgradeProcessTest {
 
 		upgradeProcess.upgrade();
 
-		Assert.assertFalse(
-			"Stale CET configuration must be deleted",
-			_configurationExists(_STALE_CET_PID_1));
-		Assert.assertFalse(
-			"Stale CET configuration must be deleted",
-			_configurationExists(_STALE_CET_PID_2));
-		Assert.assertTrue(
-			"Tracker-installed CET configuration must survive upgrade",
-			_configurationExists(_TRACKER_CET_PID));
-		Assert.assertTrue(
-			"Unrelated configuration must survive upgrade",
-			_configurationExists(_UNRELATED_PID));
-	}
-
-	private boolean _configurationExists(String pid) throws Exception {
 		try (Connection connection = DataAccess.getConnection();
 
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select configurationId from Configuration_ where " +
-					"configurationId = ?")) {
+			Statement statement = connection.createStatement();
 
-			preparedStatement.setString(1, pid);
+			ResultSet resultSet = statement.executeQuery(
+				StringBundler.concat(
+					"select configurationId from Configuration_ where ",
+					"configurationId in ('", _STALE_CET_PID_1, "', '",
+					_STALE_CET_PID_2, "', '", _TRACKER_CET_PID, "', '",
+					_UNRELATED_PID, "')"))) {
 
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				return resultSet.next();
+			Set<String> survivingPids = new HashSet<>();
+
+			while (resultSet.next()) {
+				survivingPids.add(resultSet.getString("configurationId"));
 			}
+
+			Assert.assertEquals(
+				SetUtil.fromArray(_TRACKER_CET_PID, _UNRELATED_PID),
+				survivingPids);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87765

**What is being fixed:** After upgrading a portal from 2025.q1 to 2026.q1, Control Panel custom-element client extensions render twice in the Applications Menu after redeploying the workspace bundle on the new release. The portal log shows `PortletTracker` "Portlet id … is already in use".

This was caused by LPD-67024. Before LPD-67024, client extension configs were read and stored in the `Configuration_` table. After LPD-67024, instead of being written into the database, the configs are stored only in memory. However, with the change, configs from client extensions deployed before LPD-67024 were left in the database, while configs for client extensions deployed after the LPD-67024 are present in memory, so ConfigAdmin saw both and registered them as two different client extensions that happen to have the same name.