### PR TITLE
LPD-87765 Delete persisted CET configurations on upgrade

### DIFF
--- a/modules/apps/client-extension/client-extension-service/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension Service
 Bundle-SymbolicName: com.liferay.client.extension.service
 Bundle-Version: 1.0.68
-Liferay-Require-SchemaVersion: 3.5.1
+Liferay-Require-SchemaVersion: 3.5.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/registry/ClientExtensionUpgradeStepRegistrator.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/registry/ClientExtensionUpgradeStepRegistrator.java
@@ -7,6 +7,7 @@ package com.liferay.client.extension.internal.upgrade.registry;
 
 import com.liferay.client.extension.internal.upgrade.v3_0_0.ClassNamesUpgradeProcess;
 import com.liferay.client.extension.internal.upgrade.v3_1_0.util.ClientExtensionEntryRelTable;
+import com.liferay.client.extension.internal.upgrade.v3_5_2.CETConfigurationUpgradeProcess;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
@@ -110,6 +111,9 @@ public class ClientExtensionUpgradeStepRegistrator
 				"lastPublishDate DATE null"));
 
 		registry.register("3.5.0", "3.5.1", new DummyUpgradeProcess());
+
+		registry.register(
+			"3.5.1", "3.5.2", new CETConfigurationUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -5,7 +5,6 @@
 
 package com.liferay.client.extension.internal.upgrade.v3_5_2;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -24,12 +23,9 @@ public class CETConfigurationUpgradeProcess extends UpgradeProcess {
 		}
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"delete from Configuration_ where configurationId like ",
-					"'com.liferay.client.extension.type.configuration.",
-					"CETConfiguration~%' and (dictionary is null or ",
-					"dictionary not like ",
-					"'%.client.extension.config.bundle.id=%')"))) {
+				"delete from Configuration_ where configurationId like " +
+					"'com.liferay.client.extension.type.configuration." +
+						"CETConfiguration~%'")) {
 
 			int deletedCount = preparedStatement.executeUpdate();
 

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/upgrade/v3_5_2/CETConfigurationUpgradeProcess.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.internal.upgrade.v3_5_2;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+
+/**
+ * @author Anthony Chu
+ */
+public class CETConfigurationUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (!hasTable("Configuration_")) {
+			return;
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"delete from Configuration_ where configurationId like ",
+					"'com.liferay.client.extension.type.configuration.",
+					"CETConfiguration~%' and (dictionary is null or ",
+					"dictionary not like ",
+					"'%.client.extension.config.bundle.id=%')"))) {
+
+			int deletedCount = preparedStatement.executeUpdate();
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Deleted " + deletedCount +
+						" persisted CET configurations");
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CETConfigurationUpgradeProcess.class);
+
+}

--- a/modules/apps/client-extension/client-extension-test/build.gradle
+++ b/modules/apps/client-extension/client-extension-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-props-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationUpgradeProcessTest.java
@@ -47,7 +47,7 @@ public class CETConfigurationUpgradeProcessTest {
 	public void tearDown() throws Exception {
 		DB db = DBManagerUtil.getDB();
 
-		db.runSQL("delete from Configuration_ where " + _pidsInClause());
+		db.runSQL("delete from Configuration_ where " + _PIDS_IN_CLAUSE);
 	}
 
 	@Test
@@ -69,7 +69,7 @@ public class CETConfigurationUpgradeProcessTest {
 
 			ResultSet resultSet = statement.executeQuery(
 				"select configurationId from Configuration_ where " +
-					_pidsInClause())) {
+					_PIDS_IN_CLAUSE)) {
 
 			Set<String> survivingPids = new HashSet<>();
 
@@ -96,14 +96,14 @@ public class CETConfigurationUpgradeProcessTest {
 		}
 	}
 
-	private String _pidsInClause() {
-		return StringBundler.concat(
-			"configurationId in ('", _STALE_CET_PID_1, "', '", _STALE_CET_PID_2,
-			"', '", _UNRELATED_PID, "')");
-	}
-
 	private static final String _CET_CONFIGURATION_PID_PREFIX =
 		"com.liferay.client.extension.type.configuration.CETConfiguration~";
+
+	private static final String _PIDS_IN_CLAUSE = StringBundler.concat(
+		"configurationId in ('",
+		CETConfigurationUpgradeProcessTest._STALE_CET_PID_1, "', '",
+		CETConfigurationUpgradeProcessTest._STALE_CET_PID_2, "', '",
+		CETConfigurationUpgradeProcessTest._UNRELATED_PID, "')");
 
 	private static final String _STALE_CET_PID_1 =
 		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-1/liferay.com";

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationUpgradeProcessTest.java
@@ -1,0 +1,130 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.client.extension.upgrade.v3_5_2.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Anthony Chu
+ */
+@RunWith(Arquillian.class)
+public class CETConfigurationUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@After
+	public void tearDown() throws Exception {
+		DB db = DBManagerUtil.getDB();
+
+		db.runSQL("delete from Configuration_ where " + _pidsInClause());
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_insertConfiguration(_STALE_CET_PID_1, "");
+		_insertConfiguration(_STALE_CET_PID_2, null);
+		_insertConfiguration(
+			_TRACKER_CET_PID, ".client.extension.config.bundle.id=L\"1\"\n");
+		_insertConfiguration(_UNRELATED_PID, "");
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.client.extension.internal.upgrade.v3_5_2." +
+				"CETConfigurationUpgradeProcess");
+
+		upgradeProcess.upgrade();
+
+		try (Connection connection = DataAccess.getConnection();
+
+			Statement statement = connection.createStatement();
+
+			ResultSet resultSet = statement.executeQuery(
+				"select configurationId from Configuration_ where " +
+					_pidsInClause())) {
+
+			Set<String> survivingPids = new HashSet<>();
+
+			while (resultSet.next()) {
+				survivingPids.add(resultSet.getString("configurationId"));
+			}
+
+			Assert.assertEquals(
+				SetUtil.fromArray(_TRACKER_CET_PID, _UNRELATED_PID),
+				survivingPids);
+		}
+	}
+
+	private void _insertConfiguration(String pid, String dictionary)
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"insert into Configuration_ (configurationId, dictionary) " +
+					"values(?, ?)")) {
+
+			preparedStatement.setString(1, pid);
+			preparedStatement.setString(2, dictionary);
+
+			preparedStatement.execute();
+		}
+	}
+
+	private String _pidsInClause() {
+		return StringBundler.concat(
+			"configurationId in ('", _STALE_CET_PID_1, "', '", _STALE_CET_PID_2,
+			"', '", _TRACKER_CET_PID, "', '", _UNRELATED_PID, "')");
+	}
+
+	private static final String _CET_CONFIGURATION_PID_PREFIX =
+		"com.liferay.client.extension.type.configuration.CETConfiguration~";
+
+	private static final String _STALE_CET_PID_1 =
+		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-1/liferay.com";
+
+	private static final String _STALE_CET_PID_2 =
+		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-2/liferay.com";
+
+	private static final String _TRACKER_CET_PID =
+		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-tracker/liferay.com";
+
+	private static final String _UNRELATED_PID =
+		"com.liferay.client.extension.upgrade.test.unrelated";
+
+	@Inject(
+		filter = "component.name=com.liferay.client.extension.internal.upgrade.registry.ClientExtensionUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationUpgradeProcessTest.java
+++ b/modules/apps/client-extension/client-extension-test/src/testIntegration/java/com/liferay/client/extension/upgrade/v3_5_2/test/CETConfigurationUpgradeProcessTest.java
@@ -52,11 +52,9 @@ public class CETConfigurationUpgradeProcessTest {
 
 	@Test
 	public void testUpgrade() throws Exception {
-		_insertConfiguration(_STALE_CET_PID_1, "");
-		_insertConfiguration(_STALE_CET_PID_2, null);
-		_insertConfiguration(
-			_TRACKER_CET_PID, ".client.extension.config.bundle.id=L\"1\"\n");
-		_insertConfiguration(_UNRELATED_PID, "");
+		_insertConfiguration(_STALE_CET_PID_1);
+		_insertConfiguration(_STALE_CET_PID_2);
+		_insertConfiguration(_UNRELATED_PID);
 
 		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
 			_upgradeStepRegistrator,
@@ -80,14 +78,11 @@ public class CETConfigurationUpgradeProcessTest {
 			}
 
 			Assert.assertEquals(
-				SetUtil.fromArray(_TRACKER_CET_PID, _UNRELATED_PID),
-				survivingPids);
+				SetUtil.fromArray(_UNRELATED_PID), survivingPids);
 		}
 	}
 
-	private void _insertConfiguration(String pid, String dictionary)
-		throws Exception {
-
+	private void _insertConfiguration(String pid) throws Exception {
 		try (Connection connection = DataAccess.getConnection();
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -95,7 +90,7 @@ public class CETConfigurationUpgradeProcessTest {
 					"values(?, ?)")) {
 
 			preparedStatement.setString(1, pid);
-			preparedStatement.setString(2, dictionary);
+			preparedStatement.setString(2, "");
 
 			preparedStatement.execute();
 		}
@@ -104,7 +99,7 @@ public class CETConfigurationUpgradeProcessTest {
 	private String _pidsInClause() {
 		return StringBundler.concat(
 			"configurationId in ('", _STALE_CET_PID_1, "', '", _STALE_CET_PID_2,
-			"', '", _TRACKER_CET_PID, "', '", _UNRELATED_PID, "')");
+			"', '", _UNRELATED_PID, "')");
 	}
 
 	private static final String _CET_CONFIGURATION_PID_PREFIX =
@@ -115,9 +110,6 @@ public class CETConfigurationUpgradeProcessTest {
 
 	private static final String _STALE_CET_PID_2 =
 		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-cet-2/liferay.com";
-
-	private static final String _TRACKER_CET_PID =
-		_CET_CONFIGURATION_PID_PREFIX + "upgrade-test-tracker/liferay.com";
 
 	private static final String _UNRELATED_PID =
 		"com.liferay.client.extension.upgrade.test.unrelated";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87765

LPD-67024 moved CX bundle configuration from persisted `CETConfiguration~*` rows in `Configuration_` to the in-memory `ClientExtensionConfigBundleTracker` but didn't delete the now-stale rows. After 2025.q1 → 2026.q1, they still activate `CETConfigurationFactory` alongside the tracker, surfacing as duplicate client extensions in the Control Menu.

Adds an upgrade step that deletes the leftover rows. The `.client.extension.config.bundle.id` filter excludes rows installed by `ClientExtensionConfigBundleTracker` (which writes that property on every row), so tracker-managed configurations are preserved.