### PR TITLE
LPD-90665 Publish sample-workspace AI context files separately

### DIFF
--- a/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
+++ b/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
@@ -1,0 +1,18 @@
+jobs:
+    publish-liferay-sample-workspace-agent-context-files:
+        secrets: inherit
+        uses: ./.github/workflows/ci-publish-workspace.yaml
+        with:
+            workspace-artifact-extension: agent.context.files
+            workspace-includes: .claude/**,.cursor/**,.gemini/**,.windsurf/**,.workspace-rules/**
+            workspace-name: liferay-sample-workspace
+on:
+    push:
+        branches:
+            -   master
+        paths:
+            -   workspaces/liferay-sample-workspace/.claude/**
+            -   workspaces/liferay-sample-workspace/.cursor/**
+            -   workspaces/liferay-sample-workspace/.gemini/**
+            -   workspaces/liferay-sample-workspace/.windsurf/**
+            -   workspaces/liferay-sample-workspace/.workspace-rules/**

--- a/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
+++ b/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
@@ -3,7 +3,7 @@ jobs:
         secrets: inherit
         uses: ./.github/workflows/ci-publish-workspace.yaml
         with:
-            workspace-artifact-extension: agent.context.files
+            workspace-artifact-id-suffix: agent.context.files
             workspace-includes: .claude/**,.cursor/**,.gemini/**,.windsurf/**,.workspace-rules/**
             workspace-name: liferay-sample-workspace
 on:

--- a/.github/workflows/ci-publish-workspace.yaml
+++ b/.github/workflows/ci-publish-workspace.yaml
@@ -15,11 +15,11 @@ jobs:
             -   name: Build with Ant
                 run: ant
             -   name: Run publish-workspaces task
-                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.artifact.extension="${{inputs.workspace-artifact-extension}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
+                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.artifact.id.suffix="${{inputs.workspace-artifact-id-suffix}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
 on:
     workflow_call:
         inputs:
-            workspace-artifact-extension:
+            workspace-artifact-id-suffix:
                 default: ""
                 required: false
                 type: string

--- a/.github/workflows/ci-publish-workspace.yaml
+++ b/.github/workflows/ci-publish-workspace.yaml
@@ -15,10 +15,18 @@ jobs:
             -   name: Build with Ant
                 run: ant
             -   name: Run publish-workspaces task
-                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.name=${{inputs.workspace-name}}
+                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.artifact.extension="${{inputs.workspace-artifact-extension}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
 on:
     workflow_call:
         inputs:
+            workspace-artifact-extension:
+                default: ""
+                required: false
+                type: string
+            workspace-includes:
+                default: "**/*"
+                required: false
+                type: string
             workspace-name:
                 required: true
                 type: string

--- a/build.xml
+++ b/build.xml
@@ -854,7 +854,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 		<mkdir dir="${project.dir}/dist" />
 
-		<property name="workspace.artifact.extension" value="" />
+		<property name="workspace.artifact.id.suffix" value="" />
 		<property name="workspace.includes" value="**/*" />
 		<property name="workspace.repository.url" value="https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases" />
 
@@ -883,12 +883,12 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 				<local name="artifact.id" />
 
 				<if>
-					<equals arg1="${workspace.artifact.extension}" arg2="" />
+					<equals arg1="${workspace.artifact.id.suffix}" arg2="" />
 					<then>
 						<property name="artifact.id" value="com.${processed.dir.name}" />
 					</then>
 					<else>
-						<property name="artifact.id" value="com.${processed.dir.name}.${workspace.artifact.extension}" />
+						<property name="artifact.id" value="com.${processed.dir.name}.${workspace.artifact.id.suffix}" />
 					</else>
 				</if>
 

--- a/build.xml
+++ b/build.xml
@@ -854,6 +854,10 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 		<mkdir dir="${project.dir}/dist" />
 
+		<property name="workspace.artifact.extension" value="" />
+		<property name="workspace.includes" value="**/*" />
+		<property name="workspace.repository.url" value="https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases" />
+
 		<for param="workspace.dir">
 			<path>
 				<dirset
@@ -878,7 +882,15 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 				<local name="artifact.id" />
 
-				<property name="artifact.id" value="com.${processed.dir.name}" />
+				<if>
+					<equals arg1="${workspace.artifact.extension}" arg2="" />
+					<then>
+						<property name="artifact.id" value="com.${processed.dir.name}" />
+					</then>
+					<else>
+						<property name="artifact.id" value="com.${processed.dir.name}.${workspace.artifact.extension}" />
+					</else>
+				</if>
 
 				<delete dir="${user.home}/.m2/repository/com/liferay/workspaces/${artifact.id}" />
 				<delete file="${project.dir}/dist/${artifact.id}.pom" />
@@ -890,6 +902,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 				>
 					<zipfileset
 						dir="@{workspace.dir}"
+						includes="${workspace.includes}"
 					/>
 				</zip>
 
@@ -899,7 +912,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 				<artifact:deploy file="dist/${artifact.id}.zip">
 					<pom file="dist/${artifact.id}.pom" />
-					<remoteRepository url="https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases">
+					<remoteRepository url="${workspace.repository.url}">
 						<authentication password="${sonatype.release.password}" username="${sonatype.release.username}" />
 					</remoteRepository>
 				</artifact:deploy>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90665

## What is being fixed

The agent context files under `workspaces/liferay-sample-workspace` only ship inside the full workspace artifact. Consumers cannot pull them on their own, and editing one forces a full workspace republish.

## How it is being fixed

`publish-workspaces` now takes optional `workspace.includes`, `workspace.artifact.id.suffix`, and `workspace.repository.url`, so a caller can publish a subset of a workspace under a distinct artifact name to any Nexus repo. The reusable CI workflow forwards the slice options, and a new push-triggered workflow uses them to ship just the context dirs (`.claude/`, `.cursor/`, `.gemini/`, `.windsurf/`, `.workspace-rules/`) under `agent.context.files` whenever those paths change. Defaults preserve the prior full-workspace publish.

## Why are there no tests?

Build and CI infrastructure — no unit-test surface. The workflow run on master is the verification.