### PR TITLE
LPD-93234 [SF] Recognize FeatureFlagManagerUtil.checkEnabled calls

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/WorkflowDefinitionMessageListener.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/messaging/WorkflowDefinitionMessageListener.java
@@ -7,7 +7,6 @@ package com.liferay.ai.hub.internal.messaging;
 
 import com.liferay.ai.hub.internal.audit.AuditRouterUtil;
 import com.liferay.ai.hub.internal.audit.constants.AIHubEventTypes;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.messaging.BaseMessageListener;
 import com.liferay.portal.kernel.messaging.Destination;

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesFeatureFlagsCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/PropertiesFeatureFlagsCheck.java
@@ -123,8 +123,11 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 				featureFlagKeys.addAll(
 					_getFeatureFlagKeys(fileContent, _featureFlagPattern5));
 				featureFlagKeys.addAll(
-					_getFeatureFlagKeysByFeatureFlagManagerUtilIsEnabledCall(
-						fileContent, true));
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, true, "checkEnabled"));
+				featureFlagKeys.addAll(
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, true, "isEnabled"));
 				featureFlagKeys.addAll(
 					_getFeatureFlagKeysByMapUtilSingletonDictionaryCall(
 						fileContent));
@@ -137,8 +140,11 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 				featureFlagKeys.addAll(
 					_getFeatureFlagKeys(fileContent, _featureFlagPattern2));
 				featureFlagKeys.addAll(
-					_getFeatureFlagKeysByFeatureFlagManagerUtilIsEnabledCall(
-						fileContent, false));
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, false, "checkEnabled"));
+				featureFlagKeys.addAll(
+					_getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+						fileContent, false, "isEnabled"));
 			}
 			else {
 				featureFlagKeys.addAll(
@@ -339,16 +345,16 @@ public class PropertiesFeatureFlagsCheck extends BaseFileCheck {
 		return featureFlagKeys;
 	}
 
-	private List<String>
-		_getFeatureFlagKeysByFeatureFlagManagerUtilIsEnabledCall(
-			String content, boolean javaSource) {
+	private List<String> _getFeatureFlagKeysByFeatureFlagManagerUtilCall(
+		String content, boolean javaSource, String methodName) {
 
 		List<String> featureFlagKeys = new ArrayList<>();
 
 		int x = -1;
 
 		while (true) {
-			x = content.indexOf("FeatureFlagManagerUtil.isEnabled(", x + 1);
+			x = content.indexOf(
+				"FeatureFlagManagerUtil." + methodName + "(", x + 1);
 
 			if (x == -1) {
 				return featureFlagKeys;


### PR DESCRIPTION
/cc @lfbesada
> https://liferay.atlassian.net/browse/LPD-93234
> 
> ## What Is Being Fixed
> 
> `PropertiesFeatureFlagsCheck` regenerates the `## Feature Flag` block in `portal-impl/src/portal.properties` from the set of feature-flag keys it discovers across the codebase. The Java discovery helper only scans for the literal `FeatureFlagManagerUtil.isEnabled(`. `FeatureFlagManagerUtil` exposes a second canonical gate, `checkEnabled(...)`, used wherever the desired behavior is "throw if the flag is disabled". When `checkEnabled` is the only gate for a given flag, the check finds no usage and removes the corresponding `feature.flag.<TICKET>=false` entry on every run.
> 
> Concrete trigger: the stylebooks PR https://github.com/brianchandotcom/liferay-portal/pull/175752 replaces hand-written `if (!isEnabled) throw new ...` patterns with `FeatureFlagManagerUtil.checkEnabled(...)` in `LayoutUtil` and `EnabledUtil` ([2bc50236](https://github.com/brianchandotcom/liferay-portal/pull/175752/commits/2bc50236b591f9b022458e4ffa33c7d07ead07ad), [e8a1bbe2](https://github.com/brianchandotcom/liferay-portal/pull/175752/commits/e8a1bbe2390843c8fc366d700dc28d4c52a29787)). Without this rule fix, any feature flag declared for an API gated only by `checkEnabled` would be silently dropped from `portal.properties` on the next `format-source-current-branch` run.
> 
> ## How It Is Being Fixed
> 
> Rename `_getFeatureFlagKeysByFeatureFlagManagerUtilIsEnabledCall` to `_getFeatureFlagKeysByFeatureFlagManagerUtilCall` and parameterize it with the method name. The Java and JSP/JSPF callers invoke it once with `"checkEnabled"` and once with `"isEnabled"`, so both gates register their referenced flag. No other check is touched.
> 
> ## Why Are There No Tests?
> 
> `PropertiesFeatureFlagsCheck` has no dedicated test fixture today (no `PropertiesFeatureFlagsCheckTest`, no matching `.testproperties` golden file). Adding one would establish new test infrastructure for this rule, which seems out of scope for a 5-line behavioral parity fix. The 13 existing source-formatter test classes (including `PropertiesSourceProcessorTest`) all run green with the change. Happy to add a dedicated test fixture in a follow-up if preferred.