### PR TITLE
LPD-90665 Publish sample workspace AI context files separately

### DIFF
--- a/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
+++ b/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
@@ -1,0 +1,18 @@
+jobs:
+    publish-liferay-sample-workspace-agent-context-files:
+        secrets: inherit
+        uses: ./.github/workflows/ci-publish-workspace.yaml
+        with:
+            workspace-artifact-extension: agent.context.files
+            workspace-includes: .claude/**,.cursor/**,.gemini/**,.windsurf/**,.workspace-rules/**
+            workspace-name: liferay-sample-workspace
+on:
+    push:
+        branches:
+            -   master
+        paths:
+            -   workspaces/liferay-sample-workspace/.claude/**
+            -   workspaces/liferay-sample-workspace/.cursor/**
+            -   workspaces/liferay-sample-workspace/.gemini/**
+            -   workspaces/liferay-sample-workspace/.windsurf/**
+            -   workspaces/liferay-sample-workspace/.workspace-rules/**

--- a/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
+++ b/.github/workflows/ci-publish-liferay-sample-workspace-agent-context-files.yaml
@@ -3,7 +3,7 @@ jobs:
         secrets: inherit
         uses: ./.github/workflows/ci-publish-workspace.yaml
         with:
-            workspace-artifact-extension: agent.context.files
+            workspace-artifact-id-suffix: agent.context.files
             workspace-includes: .claude/**,.cursor/**,.gemini/**,.windsurf/**,.workspace-rules/**
             workspace-name: liferay-sample-workspace
 on:

--- a/.github/workflows/ci-publish-liferay-sample-workspace-evergreen.yaml
+++ b/.github/workflows/ci-publish-liferay-sample-workspace-evergreen.yaml
@@ -1,9 +1,9 @@
 jobs:
-    publish-liferay-sample-workspace-agent-context-files:
+    publish-liferay-sample-workspace-evergreen:
         secrets: inherit
         uses: ./.github/workflows/ci-publish-workspace.yaml
         with:
-            workspace-artifact-id-suffix: agent.context.files
+            workspace-artifact-id-suffix: evergreen
             workspace-includes: .claude/**,.cursor/**,.gemini/**,.windsurf/**,.workspace-rules/**
             workspace-name: liferay-sample-workspace
 on:

--- a/.github/workflows/ci-publish-workspace.yaml
+++ b/.github/workflows/ci-publish-workspace.yaml
@@ -15,7 +15,7 @@ jobs:
             -   name: Build with Ant
                 run: ant
             -   name: Run publish-workspaces task
-                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.artifact.id.suffix="${{inputs.workspace-artifact-id-suffix}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
+                run: ant publish-workspaces -Dsonatype.release.password="${{secrets.LIFERAY_NEXUS_PASSWORD}}" -Dsonatype.release.username="${{secrets.LIFERAY_NEXUS_USERNAME}}" -Dworkspace.artifact.id.suffix="${{inputs.workspace-artifact-id-suffix}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
 on:
     workflow_call:
         inputs:

--- a/.github/workflows/ci-publish-workspace.yaml
+++ b/.github/workflows/ci-publish-workspace.yaml
@@ -15,11 +15,11 @@ jobs:
             -   name: Build with Ant
                 run: ant
             -   name: Run publish-workspaces task
-                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.artifact.extension="${{inputs.workspace-artifact-extension}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
+                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.artifact.id.suffix="${{inputs.workspace-artifact-id-suffix}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
 on:
     workflow_call:
         inputs:
-            workspace-artifact-extension:
+            workspace-artifact-id-suffix:
                 default: ""
                 required: false
                 type: string

--- a/.github/workflows/ci-publish-workspace.yaml
+++ b/.github/workflows/ci-publish-workspace.yaml
@@ -15,10 +15,18 @@ jobs:
             -   name: Build with Ant
                 run: ant
             -   name: Run publish-workspaces task
-                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.name=${{inputs.workspace-name}}
+                run: ant publish-workspaces -Dsonatype.release.password=${{secrets.LIFERAY_NEXUS_PASSWORD}} -Dsonatype.release.username=${{secrets.LIFERAY_NEXUS_USERNAME}} -Dworkspace.artifact.extension="${{inputs.workspace-artifact-extension}}" -Dworkspace.includes="${{inputs.workspace-includes}}" -Dworkspace.name="${{inputs.workspace-name}}"
 on:
     workflow_call:
         inputs:
+            workspace-artifact-extension:
+                default: ""
+                required: false
+                type: string
+            workspace-includes:
+                default: "**/*"
+                required: false
+                type: string
             workspace-name:
                 required: true
                 type: string

--- a/build.xml
+++ b/build.xml
@@ -890,6 +890,10 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 		<mkdir dir="${project.dir}/dist" />
 
+		<property name="workspace.artifact.extension" value="" />
+		<property name="workspace.includes" value="**/*" />
+		<property name="workspace.repository.url" value="https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases" />
+
 		<for param="workspace.dir">
 			<path>
 				<dirset
@@ -914,7 +918,15 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 				<local name="artifact.id" />
 
-				<property name="artifact.id" value="com.${processed.dir.name}" />
+				<if>
+					<equals arg1="${workspace.artifact.extension}" arg2="" />
+					<then>
+						<property name="artifact.id" value="com.${processed.dir.name}" />
+					</then>
+					<else>
+						<property name="artifact.id" value="com.${processed.dir.name}.${workspace.artifact.extension}" />
+					</else>
+				</if>
 
 				<delete dir="${user.home}/.m2/repository/com/liferay/workspaces/${artifact.id}" />
 				<delete file="${project.dir}/dist/${artifact.id}.pom" />
@@ -926,6 +938,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 				>
 					<zipfileset
 						dir="@{workspace.dir}"
+						includes="${workspace.includes}"
 					/>
 				</zip>
 
@@ -935,7 +948,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 				<artifact:deploy file="dist/${artifact.id}.zip">
 					<pom file="dist/${artifact.id}.pom" />
-					<remoteRepository url="https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases">
+					<remoteRepository url="${workspace.repository.url}">
 						<authentication password="${sonatype.release.password}" username="${sonatype.release.username}" />
 					</remoteRepository>
 				</artifact:deploy>

--- a/build.xml
+++ b/build.xml
@@ -890,7 +890,7 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 
 		<mkdir dir="${project.dir}/dist" />
 
-		<property name="workspace.artifact.extension" value="" />
+		<property name="workspace.artifact.id.suffix" value="" />
 		<property name="workspace.includes" value="**/*" />
 		<property name="workspace.repository.url" value="https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases" />
 
@@ -919,12 +919,12 @@ This target has been renamed to "snapshot-bundle". Please call "snapshot-bundle"
 				<local name="artifact.id" />
 
 				<if>
-					<equals arg1="${workspace.artifact.extension}" arg2="" />
+					<equals arg1="${workspace.artifact.id.suffix}" arg2="" />
 					<then>
 						<property name="artifact.id" value="com.${processed.dir.name}" />
 					</then>
 					<else>
-						<property name="artifact.id" value="com.${processed.dir.name}.${workspace.artifact.extension}" />
+						<property name="artifact.id" value="com.${processed.dir.name}.${workspace.artifact.id.suffix}" />
 					</else>
 				</if>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90665

## What Is Being Fixed

`publish-workspaces` always publishes each workspace as a single full-content zip with a fixed artifact ID and repository URL. There was no way to publish a subset of a workspace — such as the sample workspace's AI context files — as its own artifact, or to republish them when only those files change.

## How It Is Being Fixed

The `publish-workspaces` target now accepts `workspace.includes` to limit the zip's contents, `workspace.artifact.id.suffix` to publish the subset under a distinct artifact ID, and `workspace.repository.url` to override the target repository. The reusable `ci-publish-workspace.yaml` workflow exposes the new parameters as inputs, and a new `ci-publish-liferay-sample-workspace-evergreen.yaml` workflow invokes it on pushes to master that touch the sample workspace's AI context directories, publishing them with an `evergreen` suffix. Every interpolated value in the workflow's publish command is uniformly double-quoted so the glob-bearing inputs are passed to Ant literally.

## Why Are There No Tests?

The change only touches GitHub Actions workflow definitions and the Ant publishing target in `build.xml` — there is no portal code for tests to cover.

## PR Check

**pr-check: PASS** — tested on `af4b565d60302f1b57ac9a278ecc8c7c10bed21b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "af4b565d60302f1b57ac9a278ecc8c7c10bed21b"} -->