### PR TITLE
LPS-00000 Add isFooBar method to VersionUtil

### DIFF
--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/util/VersionUtil.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/util/VersionUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.gradle.plugins.workspace.internal.util;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,14 +15,6 @@ import org.gradle.api.GradleException;
  * @author Gregory Amerson
  */
 public class VersionUtil {
-
-	public static boolean isFooBar(String s) {
-		if (Objects.equals(s, "foobar")) {
-			return true;
-		}
-
-		return false;
-	}
 
 	public static boolean isDXPVersion(String targetPlatformVersion) {
 		Matcher dxpQuarterlyVersionMatcher =
@@ -35,6 +28,10 @@ public class VersionUtil {
 			targetPlatformVersion);
 
 		return dxpVersionMatcher.matches();
+	}
+
+	public static boolean isFooBar(String string) {
+		return Objects.equals(string, "foobar");
 	}
 
 	public static String normalizeTargetPlatformVersion(

--- a/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/util/VersionUtil.java
+++ b/modules/sdk/gradle-plugins-workspace/src/main/java/com/liferay/gradle/plugins/workspace/internal/util/VersionUtil.java
@@ -15,6 +15,14 @@ import org.gradle.api.GradleException;
  */
 public class VersionUtil {
 
+	public static boolean isFooBar(String s) {
+		if (Objects.equals(s, "foobar")) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public static boolean isDXPVersion(String targetPlatformVersion) {
 		Matcher dxpQuarterlyVersionMatcher =
 			_dxpQuarterlyVersionPattern.matcher(targetPlatformVersion);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-00000

## What Is Being Fixed

Nothing — this is a scratch PR for exercising the PR creation and review tooling.

## How It Is Being Fixed

Adds a trivial `isFooBar(String)` method to the workspace Gradle plugin's `VersionUtil`. A follow-up source-format commit adds the missing `java.util.Objects` import, simplifies the method to a direct `return`, and fixes member order.

## Why Are There No Tests?

This PR exists to test the PR workflow itself; the code change is throwaway.

## PR Check

**pr-check: PASS** — tested on `780958a953ff81caaaa0eb087ba46d86dabce89f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "780958a953ff81caaaa0eb087ba46d86dabce89f"} -->
